### PR TITLE
scanner: 3 eip

### DIFF
--- a/cmd/dig.go
+++ b/cmd/dig.go
@@ -21,13 +21,24 @@ var digCmd = &cobra.Command{
 		}
 
 		reg := &scanner.Registry{}
+		reg.Register(&scanner.EIPScanner{})
+
 		results, err := reg.RunAll(cmd.Context(), cfg)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "Error:", err)
 			os.Exit(1)
 		}
 
-		fmt.Printf("Found %d resources\n", len(results))
+		if len(results) == 0 {
+			fmt.Println("No unused resources found.")
+			return
+		}
+
+		fmt.Printf("Found %d unused resource(s):\n\n", len(results))
+		for _, r := range results {
+			fmt.Printf("  %-12s %-24s %-14s $%.2f/mo\n", r.Type, r.ID, r.Region, r.MonthlyCost)
+			fmt.Printf("             %s\n\n", r.Reason)
+		}
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.296.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 h1:PEgGVtPoB6NTpPrBgq
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21/go.mod h1:p+hz+PRAYlY3zcpJhPwXlLC4C+kqn70WIHwnzAfs6ps=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72MnLuFK9tJwmrbHw=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6/go.mod h1:O3h0IK87yXci+kg6flUKzJnWeziQUKciKrLjcatSNcY=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.296.2 h1:Ytu50ChAxCiDsOlBcBq8jbczXy6+QLb07T65DBJASRs=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.296.2/go.mod h1:R+2BNtUfTfhPY0RH18oL02q116bakeBWjanrbnVBqkM=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 h1:5EniKhLZe4xzL7a+fU3C2tfUN4nWIqlLesfrjkuPFTY=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7/go.mod h1:x0nZssQ3qZSnIcePWLvcoFisRXJzcTVvYpAAdYX8+GI=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 h1:c31//R3xgIJMSC8S6hEVq+38DcvUlgFY0FM6mSI5oto=

--- a/internal/scanner/eip.go
+++ b/internal/scanner/eip.go
@@ -2,8 +2,10 @@ package scanner
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 )
 
 type EIPScanner struct{}
@@ -13,7 +15,36 @@ func (e *EIPScanner) Name() string {
 }
 
 func (e *EIPScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
-	return nil, nil
+	client := ec2.NewFromConfig(cfg)
+
+	out, err := client.DescribeAddresses(ctx, &ec2.DescribeAddressesInput{})
+	if err != nil {
+		return nil, fmt.Errorf("describe addresses: %w", err)
+	}
+
+	var results []DeadResource
+	for _, addr := range out.Addresses {
+		if addr.AssociationId != nil {
+			continue
+		}
+
+		tags := make(map[string]string)
+		for _, t := range addr.Tags {
+			tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
+		}
+
+		results = append(results, DeadResource{
+			Type:        "ElasticIP",
+			ID:          aws.ToString(addr.AllocationId),
+			Name:        aws.ToString(addr.PublicIp),
+			Region:      cfg.Region,
+			Reason:      "Not associated to any instance or ENI",
+			MonthlyCost: 3.60,
+			Tags:        tags,
+		})
+	}
+
+	return results, nil
 }
 
 func (e *EIPScanner) EstimateCost(r DeadResource) float64 {

--- a/internal/scanner/eip.go
+++ b/internal/scanner/eip.go
@@ -48,5 +48,5 @@ func (e *EIPScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, 
 }
 
 func (e *EIPScanner) EstimateCost(r DeadResource) float64 {
-	return 0
+	return 3.60
 }

--- a/internal/scanner/eip.go
+++ b/internal/scanner/eip.go
@@ -1,0 +1,21 @@
+package scanner
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
+
+type EIPScanner struct{}
+
+func (e *EIPScanner) Name() string {
+	return "elastic-ip"
+}
+
+func (e *EIPScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+	return nil, nil
+}
+
+func (e *EIPScanner) EstimateCost(r DeadResource) float64 {
+	return 0
+}


### PR DESCRIPTION
This pull request adds support for detecting unused Elastic IP addresses (EIPs) in AWS and improves the output formatting for unused resources. It introduces a new scanner for Elastic IPs, updates dependencies, and enhances the CLI output for better clarity.

**New AWS resource scanner:**

* Added a new `EIPScanner` in `internal/scanner/eip.go` to detect unassociated Elastic IPs, reporting them as unused resources with estimated monthly costs and reasons.
* Registered the new `EIPScanner` in the CLI command setup to ensure it runs as part of the resource scanning process in `cmd/dig.go`.

**Dependency updates:**

* Added `github.com/aws/aws-sdk-go-v2/service/ec2` as a dependency in `go.mod` to enable interaction with EC2 resources, including Elastic IPs.

**CLI output improvements:**

* Enhanced the output in `cmd/dig.go` to clearly indicate when no unused resources are found, and to display unused resources (including EIPs) in a detailed, user-friendly format.