### PR TITLE
scanner: 5 ec2 ebs

### DIFF
--- a/cmd/dig.go
+++ b/cmd/dig.go
@@ -29,7 +29,7 @@ var digCmd = &cobra.Command{
 		for _, s := range []scanner.Scanner{
 			&scanner.EIPScanner{},
 			&scanner.EC2Scanner{MinAge: minAge},
-			&scanner.EBSScanner{MinAge: minAge},
+			&scanner.EBSScanner{},
 			&scanner.SnapshotScanner{},
 		} {
 			reg.Register(s)

--- a/cmd/dig.go
+++ b/cmd/dig.go
@@ -26,10 +26,14 @@ var digCmd = &cobra.Command{
 		minAge := time.Duration(minAgeDays) * 24 * time.Hour
 
 		reg := &scanner.Registry{}
-		reg.Register(&scanner.EIPScanner{})
-		reg.Register(&scanner.EC2Scanner{MinAge: minAge})
-		reg.Register(&scanner.EBSScanner{MinAge: minAge})
-		reg.Register(&scanner.SnapshotScanner{})
+		for _, s := range []scanner.Scanner{
+			&scanner.EIPScanner{},
+			&scanner.EC2Scanner{MinAge: minAge},
+			&scanner.EBSScanner{MinAge: minAge},
+			&scanner.SnapshotScanner{},
+		} {
+			reg.Register(s)
+		}
 
 		results, err := reg.RunAll(cmd.Context(), cfg)
 		if err != nil {

--- a/cmd/dig.go
+++ b/cmd/dig.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	reyaws "github.com/yehorkochetov/rey/internal/aws"
@@ -21,8 +22,12 @@ var digCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		minAgeDays, _ := cmd.Flags().GetInt("min-age")
+		minAge := time.Duration(minAgeDays) * 24 * time.Hour
+
 		reg := &scanner.Registry{}
 		reg.Register(&scanner.EIPScanner{})
+		reg.Register(&scanner.EC2Scanner{MinAge: minAge})
 
 		results, err := reg.RunAll(cmd.Context(), cfg)
 		if err != nil {

--- a/cmd/dig.go
+++ b/cmd/dig.go
@@ -29,6 +29,7 @@ var digCmd = &cobra.Command{
 		reg.Register(&scanner.EIPScanner{})
 		reg.Register(&scanner.EC2Scanner{MinAge: minAge})
 		reg.Register(&scanner.EBSScanner{MinAge: minAge})
+		reg.Register(&scanner.SnapshotScanner{})
 
 		results, err := reg.RunAll(cmd.Context(), cfg)
 		if err != nil {

--- a/cmd/dig.go
+++ b/cmd/dig.go
@@ -28,6 +28,7 @@ var digCmd = &cobra.Command{
 		reg := &scanner.Registry{}
 		reg.Register(&scanner.EIPScanner{})
 		reg.Register(&scanner.EC2Scanner{MinAge: minAge})
+		reg.Register(&scanner.EBSScanner{MinAge: minAge})
 
 		results, err := reg.RunAll(cmd.Context(), cfg)
 		if err != nil {

--- a/internal/scanner/ebs.go
+++ b/internal/scanner/ebs.go
@@ -1,0 +1,84 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+type EBSScanner struct {
+	MinAge time.Duration
+}
+
+func (e *EBSScanner) Name() string {
+	return "ebs-volume"
+}
+
+func (e *EBSScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+	client := ec2.NewFromConfig(cfg)
+
+	out, err := client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
+		Filters: []ec2types.Filter{
+			{
+				Name:   aws.String("status"),
+				Values: []string{"available"},
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("describe volumes: %w", err)
+	}
+
+	var results []DeadResource
+	now := time.Now().UTC()
+	for _, v := range out.Volumes {
+		if v.CreateTime == nil {
+			continue
+		}
+		age := now.Sub(*v.CreateTime)
+		if age < e.MinAge {
+			continue
+		}
+
+		tags := make(map[string]string)
+		var name string
+		for _, t := range v.Tags {
+			k := aws.ToString(t.Key)
+			val := aws.ToString(t.Value)
+			tags[k] = val
+			if k == "Name" {
+				name = val
+			}
+		}
+		id := aws.ToString(v.VolumeId)
+		if name == "" {
+			name = id
+		}
+		var size int32
+		if v.Size != nil {
+			size = *v.Size
+		}
+		days := int(age.Hours() / 24)
+
+		results = append(results, DeadResource{
+			Type:        "EBSVolume",
+			ID:          id,
+			Name:        name,
+			Region:      cfg.Region,
+			Age:         age,
+			MonthlyCost: float64(size) * 0.10,
+			Reason:      fmt.Sprintf("Unattached for %d days", days),
+			Tags:        tags,
+		})
+	}
+
+	return results, nil
+}
+
+func (e *EBSScanner) EstimateCost(r DeadResource) float64 {
+	return r.MonthlyCost
+}

--- a/internal/scanner/ebs.go
+++ b/internal/scanner/ebs.go
@@ -10,9 +10,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
 
-type EBSScanner struct {
-	MinAge time.Duration
-}
+type EBSScanner struct{}
 
 func (e *EBSScanner) Name() string {
 	return "ebs-volume"
@@ -36,12 +34,9 @@ func (e *EBSScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, 
 	var results []DeadResource
 	now := time.Now().UTC()
 	for _, v := range out.Volumes {
-		if v.CreateTime == nil {
-			continue
-		}
-		age := now.Sub(*v.CreateTime)
-		if age < e.MinAge {
-			continue
+		var age time.Duration
+		if v.CreateTime != nil {
+			age = now.Sub(*v.CreateTime)
 		}
 
 		tags := make(map[string]string)
@@ -62,7 +57,11 @@ func (e *EBSScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, 
 		if v.Size != nil {
 			size = *v.Size
 		}
-		days := int(age.Hours() / 24)
+
+		reason := "Unattached"
+		if age > 0 {
+			reason = fmt.Sprintf("Unattached for %d days", int(age.Hours()/24))
+		}
 
 		results = append(results, DeadResource{
 			Type:        "EBSVolume",
@@ -71,7 +70,7 @@ func (e *EBSScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, 
 			Region:      cfg.Region,
 			Age:         age,
 			MonthlyCost: float64(size) * 0.10,
-			Reason:      fmt.Sprintf("Unattached for %d days", days),
+			Reason:      reason,
 			Tags:        tags,
 		})
 	}

--- a/internal/scanner/ec2.go
+++ b/internal/scanner/ec2.go
@@ -1,0 +1,99 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+type EC2Scanner struct {
+	MinAge time.Duration
+}
+
+func (e *EC2Scanner) Name() string {
+	return "ec2-stopped"
+}
+
+func (e *EC2Scanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+	client := ec2.NewFromConfig(cfg)
+
+	out, err := client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+		Filters: []ec2types.Filter{
+			{
+				Name:   aws.String("instance-state-name"),
+				Values: []string{"stopped"},
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("describe instances: %w", err)
+	}
+
+	var results []DeadResource
+	now := time.Now().UTC()
+	for _, res := range out.Reservations {
+		for _, inst := range res.Instances {
+			stopTime, ok := parseStopTime(aws.ToString(inst.StateTransitionReason))
+			if !ok {
+				continue
+			}
+			age := now.Sub(stopTime)
+			if age < e.MinAge {
+				continue
+			}
+
+			tags := make(map[string]string)
+			var name string
+			for _, t := range inst.Tags {
+				k := aws.ToString(t.Key)
+				v := aws.ToString(t.Value)
+				tags[k] = v
+				if k == "Name" {
+					name = v
+				}
+			}
+			id := aws.ToString(inst.InstanceId)
+			if name == "" {
+				name = id
+			}
+			days := int(age.Hours() / 24)
+
+			results = append(results, DeadResource{
+				Type:        "EC2Instance",
+				ID:          id,
+				Name:        name,
+				Region:      cfg.Region,
+				Age:         age,
+				MonthlyCost: 0,
+				Reason:      fmt.Sprintf("Stopped for %d days, attached EBS still charging", days),
+				Tags:        tags,
+			})
+		}
+	}
+
+	return results, nil
+}
+
+func (e *EC2Scanner) EstimateCost(r DeadResource) float64 {
+	return 0
+}
+
+// parseStopTime extracts the timestamp from an EC2 StateTransitionReason
+// string like "User initiated (2024-01-15 10:30:45 GMT)".
+func parseStopTime(reason string) (time.Time, bool) {
+	open := strings.Index(reason, "(")
+	end := strings.Index(reason, " GMT)")
+	if open < 0 || end < 0 || end <= open+1 {
+		return time.Time{}, false
+	}
+	t, err := time.Parse("2006-01-02 15:04:05", reason[open+1:end])
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}

--- a/internal/scanner/snapshot.go
+++ b/internal/scanner/snapshot.go
@@ -1,0 +1,87 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+)
+
+const snapshotMaxAge = 90 * 24 * time.Hour
+
+type SnapshotScanner struct{}
+
+func (s *SnapshotScanner) Name() string {
+	return "ebs-snapshot"
+}
+
+func (s *SnapshotScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+	client := ec2.NewFromConfig(cfg)
+
+	images, err := client.DescribeImages(ctx, &ec2.DescribeImagesInput{
+		Owners: []string{"self"},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("describe images: %w", err)
+	}
+
+	amiSnapshots := make(map[string]struct{})
+	for _, img := range images.Images {
+		for _, m := range img.BlockDeviceMappings {
+			if m.Ebs == nil || m.Ebs.SnapshotId == nil {
+				continue
+			}
+			amiSnapshots[*m.Ebs.SnapshotId] = struct{}{}
+		}
+	}
+
+	snaps, err := client.DescribeSnapshots(ctx, &ec2.DescribeSnapshotsInput{
+		OwnerIds: []string{"self"},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("describe snapshots: %w", err)
+	}
+
+	var results []DeadResource
+	now := time.Now().UTC()
+	for _, snap := range snaps.Snapshots {
+		id := aws.ToString(snap.SnapshotId)
+		if _, used := amiSnapshots[id]; used {
+			continue
+		}
+		if snap.StartTime == nil {
+			continue
+		}
+		age := now.Sub(*snap.StartTime)
+		if age < snapshotMaxAge {
+			continue
+		}
+
+		tags := make(map[string]string)
+		for _, t := range snap.Tags {
+			tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
+		}
+		var size int32
+		if snap.VolumeSize != nil {
+			size = *snap.VolumeSize
+		}
+
+		results = append(results, DeadResource{
+			Type:        "EBSSnapshot",
+			ID:          id,
+			Region:      cfg.Region,
+			Age:         age,
+			MonthlyCost: float64(size) * 0.05,
+			Reason:      "Snapshot older than 90 days with no AMI reference",
+			Tags:        tags,
+		})
+	}
+
+	return results, nil
+}
+
+func (s *SnapshotScanner) EstimateCost(r DeadResource) float64 {
+	return r.MonthlyCost
+}


### PR DESCRIPTION
This pull request adds new AWS resource scanners and enhances the modularity and configurability of the scanning process. The main improvements are the introduction of scanners for EC2 instances, EBS volumes, and EBS snapshots, as well as the ability to filter EC2 instances by minimum stopped age via a new CLI flag.

**New AWS resource scanners:**

* Added `EC2Scanner` to identify stopped EC2 instances that have been stopped for longer than a configurable minimum age, skipping recently stopped instances. The scanner parses the stop time from the instance's state transition reason and includes logic for filtering by age. (`internal/scanner/ec2.go`)
* Added `EBSScanner` to detect unattached EBS volumes, calculate their age and estimated monthly cost, and report them as dead resources. (`internal/scanner/ebs.go`)
* Added `SnapshotScanner` to find EBS snapshots older than 90 days that are not referenced by any AMI, including cost estimation. (`internal/scanner/snapshot.go`)

**Command-line and registry changes:**

* Updated the `dig` command to register the new scanners and added a `--min-age` flag to control the minimum age (in days) for stopped EC2 instances to be reported. The flag value is converted to a `time.Duration` and passed to the `EC2Scanner`. (`cmd/dig.go`) [[1]](diffhunk://#diff-085400d9eb8ef4bb7a942806a13ae6c1c8f6242c45d632d03cfbbb2a9977424cR25-R36) [[2]](diffhunk://#diff-085400d9eb8ef4bb7a942806a13ae6c1c8f6242c45d632d03cfbbb2a9977424cR6)