### PR TITLE
scanner: 6 ec2 networking

### DIFF
--- a/cmd/dig.go
+++ b/cmd/dig.go
@@ -31,6 +31,11 @@ var digCmd = &cobra.Command{
 			&scanner.EC2Scanner{MinAge: minAge},
 			&scanner.EBSScanner{},
 			&scanner.SnapshotScanner{},
+			&scanner.SecurityGroupScanner{},
+			&scanner.ENIScanner{},
+			&scanner.IGWScanner{},
+			&scanner.NATGatewayScanner{},
+			&scanner.VPCEndpointScanner{},
 		} {
 			reg.Register(s)
 		}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect
+	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.56.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.296.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 h1:PEgGVtPoB6NTpPrBgq
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21/go.mod h1:p+hz+PRAYlY3zcpJhPwXlLC4C+kqn70WIHwnzAfs6ps=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72MnLuFK9tJwmrbHw=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6/go.mod h1:O3h0IK87yXci+kg6flUKzJnWeziQUKciKrLjcatSNcY=
+github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.56.1 h1:UwLZgt7jx83zDA5NCvmGlU+LNDssaUhZwyv6q+nn/Ac=
+github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.56.1/go.mod h1:+bNfizG/fpRGctZuVeH8uWht/0BLD9wUyXOKM4VaCVA=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.296.2 h1:Ytu50ChAxCiDsOlBcBq8jbczXy6+QLb07T65DBJASRs=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.296.2/go.mod h1:R+2BNtUfTfhPY0RH18oL02q116bakeBWjanrbnVBqkM=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 h1:5EniKhLZe4xzL7a+fU3C2tfUN4nWIqlLesfrjkuPFTY=

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -3,6 +3,7 @@ package output
 import (
 	"fmt"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
@@ -24,11 +25,17 @@ func RenderGraveyard(resources []scanner.DeadResource) {
 		return
 	}
 
+	sorted := make([]scanner.DeadResource, len(resources))
+	copy(sorted, resources)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return sorted[i].Type < sorted[j].Type
+	})
+
 	table := tablewriter.NewWriter(os.Stdout)
 	table.Header([]string{"Type", "Name/ID", "Region", "Age", "Monthly Cost"})
 
 	var total float64
-	for _, r := range resources {
+	for _, r := range sorted {
 		style := costStyle(r.MonthlyCost)
 		table.Append([]string{
 			style.Render(r.Type),

--- a/internal/scanner/eni.go
+++ b/internal/scanner/eni.go
@@ -1,0 +1,62 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+type ENIScanner struct{}
+
+func (e *ENIScanner) Name() string {
+	return "network-interface"
+}
+
+func (e *ENIScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+	client := ec2.NewFromConfig(cfg)
+
+	out, err := client.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
+		Filters: []ec2types.Filter{
+			{
+				Name:   aws.String("status"),
+				Values: []string{"available"},
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("describe network interfaces: %w", err)
+	}
+
+	var results []DeadResource
+	for _, eni := range out.NetworkInterfaces {
+		id := aws.ToString(eni.NetworkInterfaceId)
+		name := aws.ToString(eni.Description)
+		if name == "" {
+			name = id
+		}
+
+		tags := make(map[string]string)
+		for _, t := range eni.TagSet {
+			tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
+		}
+
+		results = append(results, DeadResource{
+			Type:        "NetworkInterface",
+			ID:          id,
+			Name:        name,
+			Region:      cfg.Region,
+			MonthlyCost: 0,
+			Reason:      "Network interface not attached to any resource",
+			Tags:        tags,
+		})
+	}
+
+	return results, nil
+}
+
+func (e *ENIScanner) EstimateCost(r DeadResource) float64 {
+	return 0
+}

--- a/internal/scanner/igw.go
+++ b/internal/scanner/igw.go
@@ -1,0 +1,72 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+type IGWScanner struct{}
+
+func (i *IGWScanner) Name() string {
+	return "internet-gateway"
+}
+
+func (i *IGWScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+	client := ec2.NewFromConfig(cfg)
+
+	out, err := client.DescribeInternetGateways(ctx, &ec2.DescribeInternetGatewaysInput{})
+	if err != nil {
+		return nil, fmt.Errorf("describe internet gateways: %w", err)
+	}
+
+	var results []DeadResource
+	for _, igw := range out.InternetGateways {
+		if hasActiveAttachment(igw.Attachments) {
+			continue
+		}
+
+		id := aws.ToString(igw.InternetGatewayId)
+		tags := make(map[string]string)
+		var name string
+		for _, t := range igw.Tags {
+			k := aws.ToString(t.Key)
+			v := aws.ToString(t.Value)
+			tags[k] = v
+			if k == "Name" {
+				name = v
+			}
+		}
+		if name == "" {
+			name = id
+		}
+
+		results = append(results, DeadResource{
+			Type:        "InternetGateway",
+			ID:          id,
+			Name:        name,
+			Region:      cfg.Region,
+			MonthlyCost: 0,
+			Reason:      "Not attached to any VPC",
+			Tags:        tags,
+		})
+	}
+
+	return results, nil
+}
+
+func (i *IGWScanner) EstimateCost(r DeadResource) float64 {
+	return 0
+}
+
+func hasActiveAttachment(attachments []ec2types.InternetGatewayAttachment) bool {
+	for _, a := range attachments {
+		if a.State != ec2types.AttachmentStatusDetached {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/scanner/nat.go
+++ b/internal/scanner/nat.go
@@ -1,0 +1,109 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+const natIdleWindow = 7 * 24 * time.Hour
+
+type NATGatewayScanner struct{}
+
+func (n *NATGatewayScanner) Name() string {
+	return "nat-gateway"
+}
+
+func (n *NATGatewayScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+	ec2Client := ec2.NewFromConfig(cfg)
+	cwClient := cloudwatch.NewFromConfig(cfg)
+
+	out, err := ec2Client.DescribeNatGateways(ctx, &ec2.DescribeNatGatewaysInput{
+		Filter: []ec2types.Filter{
+			{
+				Name:   aws.String("state"),
+				Values: []string{"available"},
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("describe nat gateways: %w", err)
+	}
+
+	now := time.Now().UTC()
+	start := now.Add(-natIdleWindow)
+
+	var results []DeadResource
+	for _, ng := range out.NatGateways {
+		id := aws.ToString(ng.NatGatewayId)
+
+		bytes, err := natBytesOut(ctx, cwClient, id, start, now)
+		if err != nil {
+			return nil, err
+		}
+		if bytes > 0 {
+			continue
+		}
+
+		tags := make(map[string]string)
+		var name string
+		for _, t := range ng.Tags {
+			k := aws.ToString(t.Key)
+			v := aws.ToString(t.Value)
+			tags[k] = v
+			if k == "Name" {
+				name = v
+			}
+		}
+		if name == "" {
+			name = id
+		}
+
+		results = append(results, DeadResource{
+			Type:        "NATGateway",
+			ID:          id,
+			Name:        name,
+			Region:      cfg.Region,
+			MonthlyCost: 32.40,
+			Reason:      "No traffic processed in 7 days",
+			Tags:        tags,
+		})
+	}
+
+	return results, nil
+}
+
+func (n *NATGatewayScanner) EstimateCost(r DeadResource) float64 {
+	return r.MonthlyCost
+}
+
+func natBytesOut(ctx context.Context, client *cloudwatch.Client, natID string, start, end time.Time) (float64, error) {
+	stats, err := client.GetMetricStatistics(ctx, &cloudwatch.GetMetricStatisticsInput{
+		Namespace:  aws.String("AWS/NATGateway"),
+		MetricName: aws.String("BytesOutToDestination"),
+		Dimensions: []cwtypes.Dimension{
+			{Name: aws.String("NatGatewayId"), Value: aws.String(natID)},
+		},
+		StartTime:  aws.Time(start),
+		EndTime:    aws.Time(end),
+		Period:     aws.Int32(int32(natIdleWindow.Seconds())),
+		Statistics: []cwtypes.Statistic{cwtypes.StatisticSum},
+	})
+	if err != nil {
+		return 0, fmt.Errorf("nat metrics %s: %w", natID, err)
+	}
+
+	var total float64
+	for _, dp := range stats.Datapoints {
+		if dp.Sum != nil {
+			total += *dp.Sum
+		}
+	}
+	return total, nil
+}

--- a/internal/scanner/security_group.go
+++ b/internal/scanner/security_group.go
@@ -1,0 +1,69 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+)
+
+type SecurityGroupScanner struct{}
+
+func (s *SecurityGroupScanner) Name() string {
+	return "security-group"
+}
+
+func (s *SecurityGroupScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+	client := ec2.NewFromConfig(cfg)
+
+	groups, err := client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{})
+	if err != nil {
+		return nil, fmt.Errorf("describe security groups: %w", err)
+	}
+
+	enis, err := client.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{})
+	if err != nil {
+		return nil, fmt.Errorf("describe network interfaces: %w", err)
+	}
+
+	inUse := make(map[string]struct{})
+	for _, eni := range enis.NetworkInterfaces {
+		for _, g := range eni.Groups {
+			inUse[aws.ToString(g.GroupId)] = struct{}{}
+		}
+	}
+
+	var results []DeadResource
+	for _, g := range groups.SecurityGroups {
+		name := aws.ToString(g.GroupName)
+		if name == "default" {
+			continue
+		}
+		id := aws.ToString(g.GroupId)
+		if _, used := inUse[id]; used {
+			continue
+		}
+
+		tags := make(map[string]string)
+		for _, t := range g.Tags {
+			tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
+		}
+
+		results = append(results, DeadResource{
+			Type:        "SecurityGroup",
+			ID:          id,
+			Name:        name,
+			Region:      cfg.Region,
+			MonthlyCost: 0,
+			Reason:      "Not attached to any resource",
+			Tags:        tags,
+		})
+	}
+
+	return results, nil
+}
+
+func (s *SecurityGroupScanner) EstimateCost(r DeadResource) float64 {
+	return 0
+}

--- a/internal/scanner/vpc_endpoint.go
+++ b/internal/scanner/vpc_endpoint.go
@@ -1,0 +1,88 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+type VPCEndpointScanner struct{}
+
+func (v *VPCEndpointScanner) Name() string {
+	return "vpc-endpoint"
+}
+
+func (v *VPCEndpointScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+	client := ec2.NewFromConfig(cfg)
+
+	out, err := client.DescribeVpcEndpoints(ctx, &ec2.DescribeVpcEndpointsInput{
+		Filters: []ec2types.Filter{
+			{
+				Name:   aws.String("vpc-endpoint-state"),
+				Values: []string{"available"},
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("describe vpc endpoints: %w", err)
+	}
+
+	var results []DeadResource
+	for _, ep := range out.VpcEndpoints {
+		if vpcEndpointInUse(ep) {
+			continue
+		}
+
+		id := aws.ToString(ep.VpcEndpointId)
+		tags := make(map[string]string)
+		var name string
+		for _, t := range ep.Tags {
+			k := aws.ToString(t.Key)
+			val := aws.ToString(t.Value)
+			tags[k] = val
+			if k == "Name" {
+				name = val
+			}
+		}
+		if name == "" {
+			name = id
+		}
+
+		results = append(results, DeadResource{
+			Type:        "VPCEndpoint",
+			ID:          id,
+			Name:        name,
+			Region:      cfg.Region,
+			MonthlyCost: vpcEndpointCost(ep.VpcEndpointType),
+			Reason:      "No route tables or security groups associated",
+			Tags:        tags,
+		})
+	}
+
+	return results, nil
+}
+
+func (v *VPCEndpointScanner) EstimateCost(r DeadResource) float64 {
+	return r.MonthlyCost
+}
+
+func vpcEndpointInUse(ep ec2types.VpcEndpoint) bool {
+	switch ep.VpcEndpointType {
+	case ec2types.VpcEndpointTypeGateway:
+		return len(ep.RouteTableIds) > 0
+	case ec2types.VpcEndpointTypeInterface, ec2types.VpcEndpointTypeGatewayLoadBalancer:
+		return len(ep.Groups) > 0
+	default:
+		return len(ep.RouteTableIds) > 0 || len(ep.Groups) > 0
+	}
+}
+
+func vpcEndpointCost(t ec2types.VpcEndpointType) float64 {
+	if t == ec2types.VpcEndpointTypeGateway {
+		return 0
+	}
+	return 7.20
+}


### PR DESCRIPTION
This pull request adds new AWS resource scanners to the project, enabling detection of additional unused resources, and improves the output by sorting resources by type. The most important changes are grouped below.

### New Resource Scanners

* Added `SecurityGroupScanner` to detect security groups not attached to any resources.
* Added `ENIScanner` to identify unattached Elastic Network Interfaces.
* Added `IGWScanner` to find Internet Gateways not attached to any VPC.
* Added `NATGatewayScanner` to detect idle NAT Gateways with no traffic in the last 7 days, including cost estimation using CloudWatch metrics.
* Added `VPCEndpointScanner` to find unused VPC Endpoints (not associated with route tables or security groups) and estimate their costs.

### Command Registration

* Registered all new scanners (`SecurityGroupScanner`, `ENIScanner`, `IGWScanner`, `NATGatewayScanner`, `VPCEndpointScanner`) in the `dig` command so they are executed as part of the main scan.

### Output Improvements

* Modified the table output to sort dead resources by their type for better readability. [[1]](diffhunk://#diff-e7db48870f37deac32208f8e0216ac90addb48069398608c346305845a601dc4R6) [[2]](diffhunk://#diff-e7db48870f37deac32208f8e0216ac90addb48069398608c346305845a601dc4R28-R38)

### Dependency Updates

* Added `github.com/aws/aws-sdk-go-v2/service/cloudwatch` to dependencies to support CloudWatch metric queries for NAT Gateway scanner.