### PR TITLE
foundation: 9 adaptive thresholds

### DIFF
--- a/cmd/dig.go
+++ b/cmd/dig.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	reyaws "github.com/yehorkochetov/rey/internal/aws"
+	"github.com/yehorkochetov/rey/internal/config"
 	"github.com/yehorkochetov/rey/internal/output"
 	"github.com/yehorkochetov/rey/internal/scanner"
 )
@@ -58,9 +59,45 @@ var digCmd = &cobra.Command{
 	},
 }
 
+// resolveThresholds merges the threshold sources by priority:
+// defaults -> config.toml -> CLI flags. A flag value of -1 means
+// the user did not set it; 0 is a deliberate "no age check".
+func resolveThresholds(cmd *cobra.Command) config.Thresholds {
+	t := config.LoadThresholds()
+	apply := func(flag string, dst *int) {
+		v, err := cmd.Flags().GetInt(flag)
+		if err != nil || v == -1 {
+			return
+		}
+		*dst = v
+	}
+	apply("ec2-stopped-days", &t.EC2StoppedDays)
+	apply("ebs-unattached-days", &t.EBSUnattachedDays)
+	apply("snapshot-age-days", &t.SnapshotAgeDays)
+	apply("dynamodb-idle-days", &t.DynamoDBIdleDays)
+	apply("elasticache-idle-days", &t.ElastiCacheIdleDays)
+	apply("nat-idle-days", &t.NATIdleDays)
+	apply("s3-multipart-days", &t.S3MultipartDays)
+	apply("s3-bucket-empty-days", &t.S3BucketEmptyDays)
+	apply("ecr-image-age-days", &t.ECRImageAgeDays)
+	apply("efs-idle-days", &t.EFSIdleDays)
+	return t
+}
+
 func init() {
 	digCmd.Flags().Int("min-age", 7, "Minimum age in days to consider a resource idle")
 	digCmd.Flags().String("export", "", "Export results to file (e.g. report.csv)")
+
+	digCmd.Flags().Int("ec2-stopped-days", -1, "Flag stopped EC2 instances older than N days (0 = any age)")
+	digCmd.Flags().Int("ebs-unattached-days", -1, "Flag unattached EBS volumes older than N days (0 = any age)")
+	digCmd.Flags().Int("snapshot-age-days", -1, "Flag EBS snapshots older than N days (0 = any age)")
+	digCmd.Flags().Int("dynamodb-idle-days", -1, "Flag DynamoDB tables idle for N days (0 = any)")
+	digCmd.Flags().Int("elasticache-idle-days", -1, "Flag ElastiCache clusters idle for N days (0 = any)")
+	digCmd.Flags().Int("nat-idle-days", -1, "Flag NAT gateways idle for N days (0 = any)")
+	digCmd.Flags().Int("s3-multipart-days", -1, "Flag incomplete multipart uploads older than N days (0 = any age)")
+	digCmd.Flags().Int("s3-bucket-empty-days", -1, "Flag empty S3 buckets older than N days (0 = any age)")
+	digCmd.Flags().Int("ecr-image-age-days", -1, "Flag untagged ECR images older than N days (0 = any age)")
+	digCmd.Flags().Int("efs-idle-days", -1, "Flag EFS file systems idle for N days (0 = any)")
 
 	rootCmd.AddCommand(digCmd)
 }

--- a/cmd/dig.go
+++ b/cmd/dig.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
 	reyaws "github.com/yehorkochetov/rey/internal/aws"
@@ -23,13 +22,10 @@ var digCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		minAgeDays, _ := cmd.Flags().GetInt("min-age")
-		minAge := time.Duration(minAgeDays) * 24 * time.Hour
-
 		reg := &scanner.Registry{}
 		for _, s := range []scanner.Scanner{
 			&scanner.EIPScanner{},
-			&scanner.EC2Scanner{MinAge: minAge},
+			&scanner.EC2Scanner{},
 			&scanner.EBSScanner{},
 			&scanner.SnapshotScanner{},
 			&scanner.SecurityGroupScanner{},
@@ -87,7 +83,6 @@ func resolveThresholds(cmd *cobra.Command) config.Thresholds {
 }
 
 func init() {
-	digCmd.Flags().Int("min-age", 7, "Minimum age in days to consider a resource idle")
 	digCmd.Flags().String("export", "", "Export results to file (e.g. report.csv)")
 
 	digCmd.Flags().Int("ec2-stopped-days", -1, "Flag stopped EC2 instances older than N days (0 = any age)")

--- a/cmd/dig.go
+++ b/cmd/dig.go
@@ -49,7 +49,9 @@ var digCmd = &cobra.Command{
 			reg.Register(s)
 		}
 
-		results, err := reg.RunAll(cmd.Context(), cfg)
+		thresholds := resolveThresholds(cmd)
+
+		results, err := reg.RunAll(cmd.Context(), cfg, thresholds)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "Error:", err)
 			os.Exit(1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,15 @@ func Init() {
 	viper.AutomaticEnv()
 
 	_ = viper.ReadInConfig()
+
+	// Keys nested under [defaults] in config.toml act as fallbacks for
+	// the top-level keys the CLI binds against. SetDefault sits below
+	// flags and env, so an explicit --profile still wins.
+	for _, k := range []string{"region", "profile", "output"} {
+		if v := viper.GetString("defaults." + k); v != "" {
+			viper.SetDefault(k, v)
+		}
+	}
 }
 
 func BindFlags(cmd *cobra.Command) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,3 +27,27 @@ func BindFlags(cmd *cobra.Command) {
 	viper.BindPFlag("profile", cmd.PersistentFlags().Lookup("profile"))
 	viper.BindPFlag("output", cmd.PersistentFlags().Lookup("output"))
 }
+
+// LoadThresholds returns thresholds from the [thresholds] section of
+// config.toml. Any key absent from the config falls back to its default —
+// a present-but-zero value is preserved as an explicit zero.
+func LoadThresholds() Thresholds {
+	t := DefaultThresholds()
+	apply := func(key string, dst *int) {
+		if viper.IsSet("thresholds." + key) {
+			*dst = viper.GetInt("thresholds." + key)
+		}
+	}
+	apply("ec2_stopped_days", &t.EC2StoppedDays)
+	apply("ebs_unattached_days", &t.EBSUnattachedDays)
+	apply("snapshot_age_days", &t.SnapshotAgeDays)
+	apply("dynamodb_idle_days", &t.DynamoDBIdleDays)
+	apply("elasticache_idle_days", &t.ElastiCacheIdleDays)
+	apply("nat_idle_days", &t.NATIdleDays)
+	apply("s3_multipart_days", &t.S3MultipartDays)
+	apply("s3_bucket_empty_days", &t.S3BucketEmptyDays)
+	apply("ecr_image_age_days", &t.ECRImageAgeDays)
+	apply("efs_idle_days", &t.EFSIdleDays)
+	apply("cloudwatch_idle_days", &t.CloudWatchIdleDays)
+	return t
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,31 @@ import (
 	"github.com/spf13/viper"
 )
 
+// ExampleConfigTOML is the documented schema for ~/.rey/config.toml.
+// Users can drop this into the file to override per-scanner thresholds;
+// any key omitted falls back to DefaultThresholds().
+const ExampleConfigTOML = `# ~/.rey/config.toml — rey configuration
+
+region  = "us-east-1"
+profile = ""
+output  = "table"
+
+# Per-scanner thresholds in days. Zero means "flag every matching
+# resource regardless of age" — never treat zero as missing.
+[thresholds]
+ec2_stopped_days      = 7
+ebs_unattached_days   = 0
+snapshot_age_days     = 90
+dynamodb_idle_days    = 14
+elasticache_idle_days = 7
+nat_idle_days         = 7
+s3_multipart_days     = 7
+s3_bucket_empty_days  = 30
+ecr_image_age_days    = 180
+efs_idle_days         = 7
+cloudwatch_idle_days  = 30
+`
+
 func Init() {
 	home, _ := os.UserHomeDir()
 	configDir := filepath.Join(home, ".rey")

--- a/internal/config/thresholds.go
+++ b/internal/config/thresholds.go
@@ -1,0 +1,34 @@
+package config
+
+// Thresholds holds the per-scanner age/idle thresholds in days.
+// Zero is a valid value meaning "flag every matching resource regardless
+// of age" — never treat 0 as a missing value.
+type Thresholds struct {
+	EC2StoppedDays      int
+	EBSUnattachedDays   int
+	SnapshotAgeDays     int
+	DynamoDBIdleDays    int
+	ElastiCacheIdleDays int
+	NATIdleDays         int
+	S3MultipartDays     int
+	S3BucketEmptyDays   int
+	ECRImageAgeDays     int
+	EFSIdleDays         int
+	CloudWatchIdleDays  int
+}
+
+func DefaultThresholds() Thresholds {
+	return Thresholds{
+		EC2StoppedDays:      7,
+		EBSUnattachedDays:   0,
+		SnapshotAgeDays:     90,
+		DynamoDBIdleDays:    14,
+		ElastiCacheIdleDays: 7,
+		NATIdleDays:         7,
+		S3MultipartDays:     7,
+		S3BucketEmptyDays:   30,
+		ECRImageAgeDays:     180,
+		EFSIdleDays:         7,
+		CloudWatchIdleDays:  30,
+	}
+}

--- a/internal/scanner/dynamodb.go
+++ b/internal/scanner/dynamodb.go
@@ -13,20 +13,19 @@ import (
 	"github.com/yehorkochetov/rey/internal/config"
 )
 
-const dynamoIdleWindow = 14 * 24 * time.Hour
-
 type DynamoDBScanner struct{}
 
 func (d *DynamoDBScanner) Name() string {
 	return "dynamodb"
 }
 
-func (d *DynamoDBScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
+func (d *DynamoDBScanner) Scan(ctx context.Context, cfg aws.Config, t config.Thresholds) ([]DeadResource, error) {
 	ddbClient := dynamodb.NewFromConfig(cfg)
 	cwClient := cloudwatch.NewFromConfig(cfg)
 
 	now := time.Now().UTC()
-	start := now.Add(-dynamoIdleWindow)
+	window := time.Duration(t.DynamoDBIdleDays) * 24 * time.Hour
+	start := now.Add(-window)
 
 	var results []DeadResource
 	paginator := dynamodb.NewListTablesPaginator(ddbClient, &dynamodb.ListTablesInput{})
@@ -37,16 +36,18 @@ func (d *DynamoDBScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thr
 		}
 
 		for _, name := range page.TableNames {
-			reads, err := dynamoCapacity(ctx, cwClient, name, "ConsumedReadCapacityUnits", start, now)
-			if err != nil {
-				return nil, err
-			}
-			writes, err := dynamoCapacity(ctx, cwClient, name, "ConsumedWriteCapacityUnits", start, now)
-			if err != nil {
-				return nil, err
-			}
-			if reads > 0 || writes > 0 {
-				continue
+			if t.DynamoDBIdleDays > 0 {
+				reads, err := dynamoCapacity(ctx, cwClient, name, "ConsumedReadCapacityUnits", start, now, window)
+				if err != nil {
+					return nil, err
+				}
+				writes, err := dynamoCapacity(ctx, cwClient, name, "ConsumedWriteCapacityUnits", start, now, window)
+				if err != nil {
+					return nil, err
+				}
+				if reads > 0 || writes > 0 {
+					continue
+				}
 			}
 
 			results = append(results, DeadResource{
@@ -55,7 +56,7 @@ func (d *DynamoDBScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thr
 				Name:        name,
 				Region:      cfg.Region,
 				MonthlyCost: 0,
-				Reason:      "No reads or writes in 14 days",
+				Reason:      idleReason("No reads or writes", t.DynamoDBIdleDays),
 				Tags:        map[string]string{},
 			})
 		}
@@ -68,7 +69,7 @@ func (d *DynamoDBScanner) EstimateCost(r DeadResource) float64 {
 	return r.MonthlyCost
 }
 
-func dynamoCapacity(ctx context.Context, client *cloudwatch.Client, table, metric string, start, end time.Time) (float64, error) {
+func dynamoCapacity(ctx context.Context, client *cloudwatch.Client, table, metric string, start, end time.Time, window time.Duration) (float64, error) {
 	stats, err := client.GetMetricStatistics(ctx, &cloudwatch.GetMetricStatisticsInput{
 		Namespace:  aws.String("AWS/DynamoDB"),
 		MetricName: aws.String(metric),
@@ -77,7 +78,7 @@ func dynamoCapacity(ctx context.Context, client *cloudwatch.Client, table, metri
 		},
 		StartTime:  aws.Time(start),
 		EndTime:    aws.Time(end),
-		Period:     aws.Int32(int32(dynamoIdleWindow.Seconds())),
+		Period:     aws.Int32(int32(window.Seconds())),
 		Statistics: []cwtypes.Statistic{cwtypes.StatisticSum},
 	})
 	if err != nil {

--- a/internal/scanner/dynamodb.go
+++ b/internal/scanner/dynamodb.go
@@ -9,6 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+
+	"github.com/yehorkochetov/rey/internal/config"
 )
 
 const dynamoIdleWindow = 14 * 24 * time.Hour
@@ -19,7 +21,7 @@ func (d *DynamoDBScanner) Name() string {
 	return "dynamodb"
 }
 
-func (d *DynamoDBScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+func (d *DynamoDBScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
 	ddbClient := dynamodb.NewFromConfig(cfg)
 	cwClient := cloudwatch.NewFromConfig(cfg)
 

--- a/internal/scanner/ebs.go
+++ b/internal/scanner/ebs.go
@@ -18,7 +18,7 @@ func (e *EBSScanner) Name() string {
 	return "ebs-volume"
 }
 
-func (e *EBSScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
+func (e *EBSScanner) Scan(ctx context.Context, cfg aws.Config, t config.Thresholds) ([]DeadResource, error) {
 	client := ec2.NewFromConfig(cfg)
 
 	out, err := client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
@@ -33,12 +33,16 @@ func (e *EBSScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Threshol
 		return nil, fmt.Errorf("describe volumes: %w", err)
 	}
 
+	minAge := time.Duration(t.EBSUnattachedDays) * 24 * time.Hour
 	var results []DeadResource
 	now := time.Now().UTC()
 	for _, v := range out.Volumes {
 		var age time.Duration
 		if v.CreateTime != nil {
 			age = now.Sub(*v.CreateTime)
+		}
+		if t.EBSUnattachedDays > 0 && age < minAge {
+			continue
 		}
 
 		tags := make(map[string]string)

--- a/internal/scanner/ebs.go
+++ b/internal/scanner/ebs.go
@@ -8,6 +8,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/yehorkochetov/rey/internal/config"
 )
 
 type EBSScanner struct{}
@@ -16,7 +18,7 @@ func (e *EBSScanner) Name() string {
 	return "ebs-volume"
 }
 
-func (e *EBSScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+func (e *EBSScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
 	client := ec2.NewFromConfig(cfg)
 
 	out, err := client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{

--- a/internal/scanner/ec2.go
+++ b/internal/scanner/ec2.go
@@ -13,15 +13,14 @@ import (
 	"github.com/yehorkochetov/rey/internal/config"
 )
 
-type EC2Scanner struct {
-	MinAge time.Duration
-}
+type EC2Scanner struct{}
 
 func (e *EC2Scanner) Name() string {
 	return "ec2-stopped"
 }
 
-func (e *EC2Scanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
+func (e *EC2Scanner) Scan(ctx context.Context, cfg aws.Config, t config.Thresholds) ([]DeadResource, error) {
+	minAge := time.Duration(t.EC2StoppedDays) * 24 * time.Hour
 	client := ec2.NewFromConfig(cfg)
 
 	out, err := client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
@@ -45,7 +44,7 @@ func (e *EC2Scanner) Scan(ctx context.Context, cfg aws.Config, _ config.Threshol
 				continue
 			}
 			age := now.Sub(stopTime)
-			if age < e.MinAge {
+			if t.EC2StoppedDays > 0 && age < minAge {
 				continue
 			}
 

--- a/internal/scanner/ec2.go
+++ b/internal/scanner/ec2.go
@@ -9,6 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/yehorkochetov/rey/internal/config"
 )
 
 type EC2Scanner struct {
@@ -19,7 +21,7 @@ func (e *EC2Scanner) Name() string {
 	return "ec2-stopped"
 }
 
-func (e *EC2Scanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+func (e *EC2Scanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
 	client := ec2.NewFromConfig(cfg)
 
 	out, err := client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{

--- a/internal/scanner/ecr.go
+++ b/internal/scanner/ecr.go
@@ -11,15 +11,14 @@ import (
 	"github.com/yehorkochetov/rey/internal/config"
 )
 
-const ecrImageMaxAge = 180 * 24 * time.Hour
-
 type ECRScanner struct{}
 
 func (e *ECRScanner) Name() string {
 	return "ecr-image"
 }
 
-func (e *ECRScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
+func (e *ECRScanner) Scan(ctx context.Context, cfg aws.Config, t config.Thresholds) ([]DeadResource, error) {
+	minAge := time.Duration(t.ECRImageAgeDays) * 24 * time.Hour
 	client := ecr.NewFromConfig(cfg)
 
 	now := time.Now().UTC()
@@ -49,7 +48,7 @@ func (e *ECRScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Threshol
 						continue
 					}
 					age := now.Sub(*img.ImagePushedAt)
-					if age < ecrImageMaxAge {
+					if t.ECRImageAgeDays > 0 && age < minAge {
 						continue
 					}
 					if hasLatestTag(img.ImageTags) {
@@ -74,7 +73,7 @@ func (e *ECRScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Threshol
 						Region:      cfg.Region,
 						Age:         age,
 						MonthlyCost: sizeGB * 0.10,
-						Reason:      "Untagged ECR image older than 180 days",
+						Reason:      ecrImageReason(t.ECRImageAgeDays),
 						Tags:        map[string]string{},
 					})
 				}
@@ -87,6 +86,13 @@ func (e *ECRScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Threshol
 
 func (e *ECRScanner) EstimateCost(r DeadResource) float64 {
 	return r.MonthlyCost
+}
+
+func ecrImageReason(days int) string {
+	if days <= 0 {
+		return "Untagged ECR image"
+	}
+	return fmt.Sprintf("Untagged ECR image older than %d days", days)
 }
 
 func hasLatestTag(tags []string) bool {

--- a/internal/scanner/ecr.go
+++ b/internal/scanner/ecr.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
+
+	"github.com/yehorkochetov/rey/internal/config"
 )
 
 const ecrImageMaxAge = 180 * 24 * time.Hour
@@ -17,7 +19,7 @@ func (e *ECRScanner) Name() string {
 	return "ecr-image"
 }
 
-func (e *ECRScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+func (e *ECRScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
 	client := ecr.NewFromConfig(cfg)
 
 	now := time.Now().UTC()

--- a/internal/scanner/efs.go
+++ b/internal/scanner/efs.go
@@ -13,20 +13,19 @@ import (
 	"github.com/yehorkochetov/rey/internal/config"
 )
 
-const efsIdleWindow = 7 * 24 * time.Hour
-
 type EFSScanner struct{}
 
 func (e *EFSScanner) Name() string {
 	return "efs"
 }
 
-func (e *EFSScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
+func (e *EFSScanner) Scan(ctx context.Context, cfg aws.Config, t config.Thresholds) ([]DeadResource, error) {
 	efsClient := efs.NewFromConfig(cfg)
 	cwClient := cloudwatch.NewFromConfig(cfg)
 
 	now := time.Now().UTC()
-	start := now.Add(-efsIdleWindow)
+	window := time.Duration(t.EFSIdleDays) * 24 * time.Hour
+	start := now.Add(-window)
 
 	var results []DeadResource
 	paginator := efs.NewDescribeFileSystemsPaginator(efsClient, &efs.DescribeFileSystemsInput{})
@@ -39,12 +38,14 @@ func (e *EFSScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Threshol
 		for _, fs := range page.FileSystems {
 			id := aws.ToString(fs.FileSystemId)
 
-			io, err := efsMeteredIO(ctx, cwClient, id, start, now)
-			if err != nil {
-				return nil, err
-			}
-			if io > 0 {
-				continue
+			if t.EFSIdleDays > 0 {
+				io, err := efsMeteredIO(ctx, cwClient, id, start, now, window)
+				if err != nil {
+					return nil, err
+				}
+				if io > 0 {
+					continue
+				}
 			}
 
 			tags := make(map[string]string)
@@ -72,7 +73,7 @@ func (e *EFSScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Threshol
 				Name:        name,
 				Region:      cfg.Region,
 				MonthlyCost: sizeGB * 0.30,
-				Reason:      "No IO activity in 7 days",
+				Reason:      idleReason("No IO activity", t.EFSIdleDays),
 				Tags:        tags,
 			})
 		}
@@ -85,7 +86,7 @@ func (e *EFSScanner) EstimateCost(r DeadResource) float64 {
 	return r.MonthlyCost
 }
 
-func efsMeteredIO(ctx context.Context, client *cloudwatch.Client, fsID string, start, end time.Time) (float64, error) {
+func efsMeteredIO(ctx context.Context, client *cloudwatch.Client, fsID string, start, end time.Time, window time.Duration) (float64, error) {
 	stats, err := client.GetMetricStatistics(ctx, &cloudwatch.GetMetricStatisticsInput{
 		Namespace:  aws.String("AWS/EFS"),
 		MetricName: aws.String("MeteredIOBytes"),
@@ -94,7 +95,7 @@ func efsMeteredIO(ctx context.Context, client *cloudwatch.Client, fsID string, s
 		},
 		StartTime:  aws.Time(start),
 		EndTime:    aws.Time(end),
-		Period:     aws.Int32(int32(efsIdleWindow.Seconds())),
+		Period:     aws.Int32(int32(window.Seconds())),
 		Statistics: []cwtypes.Statistic{cwtypes.StatisticSum},
 	})
 	if err != nil {

--- a/internal/scanner/efs.go
+++ b/internal/scanner/efs.go
@@ -9,6 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/aws/aws-sdk-go-v2/service/efs"
+
+	"github.com/yehorkochetov/rey/internal/config"
 )
 
 const efsIdleWindow = 7 * 24 * time.Hour
@@ -19,7 +21,7 @@ func (e *EFSScanner) Name() string {
 	return "efs"
 }
 
-func (e *EFSScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+func (e *EFSScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
 	efsClient := efs.NewFromConfig(cfg)
 	cwClient := cloudwatch.NewFromConfig(cfg)
 

--- a/internal/scanner/eip.go
+++ b/internal/scanner/eip.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+
+	"github.com/yehorkochetov/rey/internal/config"
 )
 
 type EIPScanner struct{}
@@ -14,7 +16,7 @@ func (e *EIPScanner) Name() string {
 	return "elastic-ip"
 }
 
-func (e *EIPScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+func (e *EIPScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
 	client := ec2.NewFromConfig(cfg)
 
 	out, err := client.DescribeAddresses(ctx, &ec2.DescribeAddressesInput{})

--- a/internal/scanner/elasticache.go
+++ b/internal/scanner/elasticache.go
@@ -9,6 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
+
+	"github.com/yehorkochetov/rey/internal/config"
 )
 
 const elastiCacheIdleWindow = 7 * 24 * time.Hour
@@ -19,7 +21,7 @@ func (e *ElastiCacheScanner) Name() string {
 	return "elasticache"
 }
 
-func (e *ElastiCacheScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+func (e *ElastiCacheScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
 	ecClient := elasticache.NewFromConfig(cfg)
 	cwClient := cloudwatch.NewFromConfig(cfg)
 

--- a/internal/scanner/elasticache.go
+++ b/internal/scanner/elasticache.go
@@ -13,20 +13,19 @@ import (
 	"github.com/yehorkochetov/rey/internal/config"
 )
 
-const elastiCacheIdleWindow = 7 * 24 * time.Hour
-
 type ElastiCacheScanner struct{}
 
 func (e *ElastiCacheScanner) Name() string {
 	return "elasticache"
 }
 
-func (e *ElastiCacheScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
+func (e *ElastiCacheScanner) Scan(ctx context.Context, cfg aws.Config, t config.Thresholds) ([]DeadResource, error) {
 	ecClient := elasticache.NewFromConfig(cfg)
 	cwClient := cloudwatch.NewFromConfig(cfg)
 
 	now := time.Now().UTC()
-	start := now.Add(-elastiCacheIdleWindow)
+	window := time.Duration(t.ElastiCacheIdleDays) * 24 * time.Hour
+	start := now.Add(-window)
 
 	var results []DeadResource
 	paginator := elasticache.NewDescribeCacheClustersPaginator(ecClient, &elasticache.DescribeCacheClustersInput{})
@@ -39,12 +38,14 @@ func (e *ElastiCacheScanner) Scan(ctx context.Context, cfg aws.Config, _ config.
 		for _, c := range page.CacheClusters {
 			id := aws.ToString(c.CacheClusterId)
 
-			avg, err := elastiCacheConnections(ctx, cwClient, id, start, now)
-			if err != nil {
-				return nil, err
-			}
-			if avg > 0 {
-				continue
+			if t.ElastiCacheIdleDays > 0 {
+				avg, err := elastiCacheConnections(ctx, cwClient, id, start, now, window)
+				if err != nil {
+					return nil, err
+				}
+				if avg > 0 {
+					continue
+				}
 			}
 
 			results = append(results, DeadResource{
@@ -53,7 +54,7 @@ func (e *ElastiCacheScanner) Scan(ctx context.Context, cfg aws.Config, _ config.
 				Name:        id,
 				Region:      cfg.Region,
 				MonthlyCost: 0,
-				Reason:      "No connections in 7 days",
+				Reason:      idleReason("No connections", t.ElastiCacheIdleDays),
 				Tags:        map[string]string{},
 			})
 		}
@@ -66,7 +67,7 @@ func (e *ElastiCacheScanner) EstimateCost(r DeadResource) float64 {
 	return r.MonthlyCost
 }
 
-func elastiCacheConnections(ctx context.Context, client *cloudwatch.Client, clusterID string, start, end time.Time) (float64, error) {
+func elastiCacheConnections(ctx context.Context, client *cloudwatch.Client, clusterID string, start, end time.Time, window time.Duration) (float64, error) {
 	stats, err := client.GetMetricStatistics(ctx, &cloudwatch.GetMetricStatisticsInput{
 		Namespace:  aws.String("AWS/ElastiCache"),
 		MetricName: aws.String("CurrConnections"),
@@ -75,7 +76,7 @@ func elastiCacheConnections(ctx context.Context, client *cloudwatch.Client, clus
 		},
 		StartTime:  aws.Time(start),
 		EndTime:    aws.Time(end),
-		Period:     aws.Int32(int32(elastiCacheIdleWindow.Seconds())),
+		Period:     aws.Int32(int32(window.Seconds())),
 		Statistics: []cwtypes.Statistic{cwtypes.StatisticAverage},
 	})
 	if err != nil {

--- a/internal/scanner/eni.go
+++ b/internal/scanner/eni.go
@@ -7,6 +7,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/yehorkochetov/rey/internal/config"
 )
 
 type ENIScanner struct{}
@@ -15,7 +17,7 @@ func (e *ENIScanner) Name() string {
 	return "network-interface"
 }
 
-func (e *ENIScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+func (e *ENIScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
 	client := ec2.NewFromConfig(cfg)
 
 	out, err := client.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{

--- a/internal/scanner/igw.go
+++ b/internal/scanner/igw.go
@@ -7,6 +7,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/yehorkochetov/rey/internal/config"
 )
 
 type IGWScanner struct{}
@@ -15,7 +17,7 @@ func (i *IGWScanner) Name() string {
 	return "internet-gateway"
 }
 
-func (i *IGWScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+func (i *IGWScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
 	client := ec2.NewFromConfig(cfg)
 
 	out, err := client.DescribeInternetGateways(ctx, &ec2.DescribeInternetGatewaysInput{})

--- a/internal/scanner/nat.go
+++ b/internal/scanner/nat.go
@@ -14,15 +14,13 @@ import (
 	"github.com/yehorkochetov/rey/internal/config"
 )
 
-const natIdleWindow = 7 * 24 * time.Hour
-
 type NATGatewayScanner struct{}
 
 func (n *NATGatewayScanner) Name() string {
 	return "nat-gateway"
 }
 
-func (n *NATGatewayScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
+func (n *NATGatewayScanner) Scan(ctx context.Context, cfg aws.Config, t config.Thresholds) ([]DeadResource, error) {
 	ec2Client := ec2.NewFromConfig(cfg)
 	cwClient := cloudwatch.NewFromConfig(cfg)
 
@@ -39,18 +37,21 @@ func (n *NATGatewayScanner) Scan(ctx context.Context, cfg aws.Config, _ config.T
 	}
 
 	now := time.Now().UTC()
-	start := now.Add(-natIdleWindow)
+	window := time.Duration(t.NATIdleDays) * 24 * time.Hour
+	start := now.Add(-window)
 
 	var results []DeadResource
 	for _, ng := range out.NatGateways {
 		id := aws.ToString(ng.NatGatewayId)
 
-		bytes, err := natBytesOut(ctx, cwClient, id, start, now)
-		if err != nil {
-			return nil, err
-		}
-		if bytes > 0 {
-			continue
+		if t.NATIdleDays > 0 {
+			bytes, err := natBytesOut(ctx, cwClient, id, start, now, window)
+			if err != nil {
+				return nil, err
+			}
+			if bytes > 0 {
+				continue
+			}
 		}
 
 		tags := make(map[string]string)
@@ -73,7 +74,7 @@ func (n *NATGatewayScanner) Scan(ctx context.Context, cfg aws.Config, _ config.T
 			Name:        name,
 			Region:      cfg.Region,
 			MonthlyCost: 32.40,
-			Reason:      "No traffic processed in 7 days",
+			Reason:      idleReason("No traffic processed", t.NATIdleDays),
 			Tags:        tags,
 		})
 	}
@@ -85,7 +86,7 @@ func (n *NATGatewayScanner) EstimateCost(r DeadResource) float64 {
 	return r.MonthlyCost
 }
 
-func natBytesOut(ctx context.Context, client *cloudwatch.Client, natID string, start, end time.Time) (float64, error) {
+func natBytesOut(ctx context.Context, client *cloudwatch.Client, natID string, start, end time.Time, window time.Duration) (float64, error) {
 	stats, err := client.GetMetricStatistics(ctx, &cloudwatch.GetMetricStatisticsInput{
 		Namespace:  aws.String("AWS/NATGateway"),
 		MetricName: aws.String("BytesOutToDestination"),
@@ -94,7 +95,7 @@ func natBytesOut(ctx context.Context, client *cloudwatch.Client, natID string, s
 		},
 		StartTime:  aws.Time(start),
 		EndTime:    aws.Time(end),
-		Period:     aws.Int32(int32(natIdleWindow.Seconds())),
+		Period:     aws.Int32(int32(window.Seconds())),
 		Statistics: []cwtypes.Statistic{cwtypes.StatisticSum},
 	})
 	if err != nil {

--- a/internal/scanner/nat.go
+++ b/internal/scanner/nat.go
@@ -10,6 +10,8 @@ import (
 	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/yehorkochetov/rey/internal/config"
 )
 
 const natIdleWindow = 7 * 24 * time.Hour
@@ -20,7 +22,7 @@ func (n *NATGatewayScanner) Name() string {
 	return "nat-gateway"
 }
 
-func (n *NATGatewayScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+func (n *NATGatewayScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
 	ec2Client := ec2.NewFromConfig(cfg)
 	cwClient := cloudwatch.NewFromConfig(cfg)
 

--- a/internal/scanner/rds.go
+++ b/internal/scanner/rds.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
+
+	"github.com/yehorkochetov/rey/internal/config"
 )
 
 type RDSScanner struct{}
@@ -14,7 +16,7 @@ func (r *RDSScanner) Name() string {
 	return "rds-instance"
 }
 
-func (r *RDSScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+func (r *RDSScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
 	client := rds.NewFromConfig(cfg)
 
 	var results []DeadResource

--- a/internal/scanner/rds_snapshot.go
+++ b/internal/scanner/rds_snapshot.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
+
+	"github.com/yehorkochetov/rey/internal/config"
 )
 
 const rdsSnapshotMaxAge = 90 * 24 * time.Hour
@@ -17,7 +19,7 @@ func (s *RDSSnapshotScanner) Name() string {
 	return "rds-snapshot"
 }
 
-func (s *RDSSnapshotScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+func (s *RDSSnapshotScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
 	client := rds.NewFromConfig(cfg)
 
 	now := time.Now().UTC()

--- a/internal/scanner/registry.go
+++ b/internal/scanner/registry.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+
+	"github.com/yehorkochetov/rey/internal/config"
 )
 
 type Registry struct {
@@ -15,7 +17,7 @@ func (r *Registry) Register(s Scanner) {
 	r.scanners = append(r.scanners, s)
 }
 
-func (r *Registry) RunAll(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+func (r *Registry) RunAll(ctx context.Context, cfg aws.Config, t config.Thresholds) ([]DeadResource, error) {
 	var (
 		mu      sync.Mutex
 		wg      sync.WaitGroup
@@ -27,7 +29,7 @@ func (r *Registry) RunAll(ctx context.Context, cfg aws.Config) ([]DeadResource, 
 		wg.Add(1)
 		go func(s Scanner) {
 			defer wg.Done()
-			found, err := s.Scan(ctx, cfg)
+			found, err := s.Scan(ctx, cfg, t)
 			mu.Lock()
 			defer mu.Unlock()
 			if err != nil {

--- a/internal/scanner/s3_bucket.go
+++ b/internal/scanner/s3_bucket.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/yehorkochetov/rey/internal/config"
 )
 
 const emptyBucketMinAge = 30 * 24 * time.Hour
@@ -17,7 +19,7 @@ func (s *S3BucketScanner) Name() string {
 	return "s3-bucket"
 }
 
-func (s *S3BucketScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+func (s *S3BucketScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
 	client := s3.NewFromConfig(cfg)
 
 	buckets, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})

--- a/internal/scanner/s3_bucket.go
+++ b/internal/scanner/s3_bucket.go
@@ -11,15 +11,14 @@ import (
 	"github.com/yehorkochetov/rey/internal/config"
 )
 
-const emptyBucketMinAge = 30 * 24 * time.Hour
-
 type S3BucketScanner struct{}
 
 func (s *S3BucketScanner) Name() string {
 	return "s3-bucket"
 }
 
-func (s *S3BucketScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
+func (s *S3BucketScanner) Scan(ctx context.Context, cfg aws.Config, t config.Thresholds) ([]DeadResource, error) {
+	minAge := time.Duration(t.S3BucketEmptyDays) * 24 * time.Hour
 	client := s3.NewFromConfig(cfg)
 
 	buckets, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
@@ -32,11 +31,11 @@ func (s *S3BucketScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thr
 
 	for _, b := range buckets.Buckets {
 		name := aws.ToString(b.Name)
-		if b.CreationDate == nil {
-			continue
+		var age time.Duration
+		if b.CreationDate != nil {
+			age = now.Sub(*b.CreationDate)
 		}
-		age := now.Sub(*b.CreationDate)
-		if age < emptyBucketMinAge {
+		if t.S3BucketEmptyDays > 0 && age < minAge {
 			continue
 		}
 
@@ -66,7 +65,7 @@ func (s *S3BucketScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thr
 			Region:      cfg.Region,
 			Age:         age,
 			MonthlyCost: 0,
-			Reason:      "Empty bucket older than 30 days",
+			Reason:      emptyBucketReason(t.S3BucketEmptyDays),
 			Tags:        map[string]string{},
 		})
 	}
@@ -76,4 +75,11 @@ func (s *S3BucketScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thr
 
 func (s *S3BucketScanner) EstimateCost(r DeadResource) float64 {
 	return r.MonthlyCost
+}
+
+func emptyBucketReason(days int) string {
+	if days <= 0 {
+		return "Empty bucket"
+	}
+	return fmt.Sprintf("Empty bucket older than %d days", days)
 }

--- a/internal/scanner/s3_multipart.go
+++ b/internal/scanner/s3_multipart.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/yehorkochetov/rey/internal/config"
 )
 
 const multipartMaxAge = 7 * 24 * time.Hour
@@ -17,7 +19,7 @@ func (s *S3MultipartScanner) Name() string {
 	return "s3-multipart"
 }
 
-func (s *S3MultipartScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+func (s *S3MultipartScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
 	client := s3.NewFromConfig(cfg)
 
 	buckets, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})

--- a/internal/scanner/s3_multipart.go
+++ b/internal/scanner/s3_multipart.go
@@ -11,15 +11,14 @@ import (
 	"github.com/yehorkochetov/rey/internal/config"
 )
 
-const multipartMaxAge = 7 * 24 * time.Hour
-
 type S3MultipartScanner struct{}
 
 func (s *S3MultipartScanner) Name() string {
 	return "s3-multipart"
 }
 
-func (s *S3MultipartScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
+func (s *S3MultipartScanner) Scan(ctx context.Context, cfg aws.Config, t config.Thresholds) ([]DeadResource, error) {
+	minAge := time.Duration(t.S3MultipartDays) * 24 * time.Hour
 	client := s3.NewFromConfig(cfg)
 
 	buckets, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
@@ -55,7 +54,7 @@ func (s *S3MultipartScanner) Scan(ctx context.Context, cfg aws.Config, _ config.
 					continue
 				}
 				age := now.Sub(*up.Initiated)
-				if age < multipartMaxAge {
+				if t.S3MultipartDays > 0 && age < minAge {
 					continue
 				}
 
@@ -75,7 +74,7 @@ func (s *S3MultipartScanner) Scan(ctx context.Context, cfg aws.Config, _ config.
 					Region:      cfg.Region,
 					Age:         age,
 					MonthlyCost: sizeGB * 0.023,
-					Reason:      "Incomplete multipart upload older than 7 days",
+					Reason:      multipartReason(t.S3MultipartDays),
 					Tags:        map[string]string{},
 				})
 			}
@@ -87,6 +86,13 @@ func (s *S3MultipartScanner) Scan(ctx context.Context, cfg aws.Config, _ config.
 
 func (s *S3MultipartScanner) EstimateCost(r DeadResource) float64 {
 	return r.MonthlyCost
+}
+
+func multipartReason(days int) string {
+	if days <= 0 {
+		return "Incomplete multipart upload"
+	}
+	return fmt.Sprintf("Incomplete multipart upload older than %d days", days)
 }
 
 func bucketRegion(ctx context.Context, client *s3.Client, bucket string) (string, error) {

--- a/internal/scanner/security_group.go
+++ b/internal/scanner/security_group.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+
+	"github.com/yehorkochetov/rey/internal/config"
 )
 
 type SecurityGroupScanner struct{}
@@ -14,7 +16,7 @@ func (s *SecurityGroupScanner) Name() string {
 	return "security-group"
 }
 
-func (s *SecurityGroupScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+func (s *SecurityGroupScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
 	client := ec2.NewFromConfig(cfg)
 
 	groups, err := client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{})

--- a/internal/scanner/snapshot.go
+++ b/internal/scanner/snapshot.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+
+	"github.com/yehorkochetov/rey/internal/config"
 )
 
 const snapshotMaxAge = 90 * 24 * time.Hour
@@ -17,7 +19,7 @@ func (s *SnapshotScanner) Name() string {
 	return "ebs-snapshot"
 }
 
-func (s *SnapshotScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+func (s *SnapshotScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
 	client := ec2.NewFromConfig(cfg)
 
 	images, err := client.DescribeImages(ctx, &ec2.DescribeImagesInput{

--- a/internal/scanner/snapshot.go
+++ b/internal/scanner/snapshot.go
@@ -11,15 +11,14 @@ import (
 	"github.com/yehorkochetov/rey/internal/config"
 )
 
-const snapshotMaxAge = 90 * 24 * time.Hour
-
 type SnapshotScanner struct{}
 
 func (s *SnapshotScanner) Name() string {
 	return "ebs-snapshot"
 }
 
-func (s *SnapshotScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
+func (s *SnapshotScanner) Scan(ctx context.Context, cfg aws.Config, t config.Thresholds) ([]DeadResource, error) {
+	minAge := time.Duration(t.SnapshotAgeDays) * 24 * time.Hour
 	client := ec2.NewFromConfig(cfg)
 
 	images, err := client.DescribeImages(ctx, &ec2.DescribeImagesInput{
@@ -57,7 +56,7 @@ func (s *SnapshotScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thr
 			continue
 		}
 		age := now.Sub(*snap.StartTime)
-		if age < snapshotMaxAge {
+		if t.SnapshotAgeDays > 0 && age < minAge {
 			continue
 		}
 
@@ -76,7 +75,7 @@ func (s *SnapshotScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thr
 			Region:      cfg.Region,
 			Age:         age,
 			MonthlyCost: float64(size) * 0.05,
-			Reason:      "Snapshot older than 90 days with no AMI reference",
+			Reason:      snapshotReason(t.SnapshotAgeDays),
 			Tags:        tags,
 		})
 	}
@@ -86,4 +85,11 @@ func (s *SnapshotScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thr
 
 func (s *SnapshotScanner) EstimateCost(r DeadResource) float64 {
 	return r.MonthlyCost
+}
+
+func snapshotReason(days int) string {
+	if days <= 0 {
+		return "Snapshot with no AMI reference"
+	}
+	return fmt.Sprintf("Snapshot older than %d days with no AMI reference", days)
 }

--- a/internal/scanner/types.go
+++ b/internal/scanner/types.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -27,4 +28,14 @@ type Scanner interface {
 	Name() string
 	Scan(ctx context.Context, cfg aws.Config, t config.Thresholds) ([]DeadResource, error)
 	EstimateCost(r DeadResource) float64
+}
+
+// idleReason builds the human-readable reason for an idle resource.
+// A non-positive day count means the threshold is disabled, so the
+// reason drops the day suffix.
+func idleReason(prefix string, days int) string {
+	if days <= 0 {
+		return prefix
+	}
+	return fmt.Sprintf("%s in %d days", prefix, days)
 }

--- a/internal/scanner/types.go
+++ b/internal/scanner/types.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+
+	"github.com/yehorkochetov/rey/internal/config"
 )
 
 // DeadResource represents a single wasted or idle AWS resource.
@@ -23,6 +25,6 @@ type DeadResource struct {
 // Each scanner is responsible for one resource type.
 type Scanner interface {
 	Name() string
-	Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error)
+	Scan(ctx context.Context, cfg aws.Config, t config.Thresholds) ([]DeadResource, error)
 	EstimateCost(r DeadResource) float64
 }

--- a/internal/scanner/vpc_endpoint.go
+++ b/internal/scanner/vpc_endpoint.go
@@ -7,6 +7,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/yehorkochetov/rey/internal/config"
 )
 
 type VPCEndpointScanner struct{}
@@ -15,7 +17,7 @@ func (v *VPCEndpointScanner) Name() string {
 	return "vpc-endpoint"
 }
 
-func (v *VPCEndpointScanner) Scan(ctx context.Context, cfg aws.Config) ([]DeadResource, error) {
+func (v *VPCEndpointScanner) Scan(ctx context.Context, cfg aws.Config, _ config.Thresholds) ([]DeadResource, error) {
 	client := ec2.NewFromConfig(cfg)
 
 	out, err := client.DescribeVpcEndpoints(ctx, &ec2.DescribeVpcEndpointsInput{


### PR DESCRIPTION
This pull request introduces a new, unified system for configuring per-resource age/idle thresholds across the CLI, configuration file, and code defaults. Instead of hardcoded or scattered threshold values, all scanners now receive their thresholds from a central `Thresholds` struct, which can be customized by users via CLI flags or a `[thresholds]` section in `~/.rey/config.toml`. This makes the tool much more flexible and user-friendly, allowing for fine-grained control over resource cleanup criteria.

Key changes include:

### Threshold Configuration System

* Introduced a new `Thresholds` struct in `internal/config/thresholds.go` to hold all per-scanner threshold values, along with a `DefaultThresholds()` function.
* Added the `LoadThresholds()` function in `internal/config/config.go` to load thresholds from the `[thresholds]` section of `config.toml`, falling back to defaults for missing keys but preserving explicit zeros.
* Added CLI flags for each threshold (e.g., `--ec2-stopped-days`, `--ebs-unattached-days`, etc.) and a `resolveThresholds()` helper in `cmd/dig.go` to merge CLI, config, and default values by priority.

### Scanner Refactoring

* Updated all scanner interfaces (`EC2Scanner`, `EBSScanner`, `DynamoDBScanner`, `ECRScanner`, `EFSScanner`, `EIPScanner`) to accept a `Thresholds` parameter and use the appropriate threshold for filtering resources. [[1]](diffhunk://#diff-1056de04f7a65e65c42e8f5000f442802b9f16bbcb02b0e80f1cd130e649b4e2R12-R23) [[2]](diffhunk://#diff-46f8cd4cd117cf137843db0591dc1bf0c03524ace3643f60b7aeac5af3aba45fR11-R12) [[3]](diffhunk://#diff-5a144e117422d73d08c93fe203441b426bf71d99bc1f6c554f11210dc8f2f37fL12-R28) [[4]](diffhunk://#diff-d7dcb6c87cc7b0dad8a935ad07cf9f6cdef7939ec9252b7ce35651fe3ff077a7L10-R21) [[5]](diffhunk://#diff-3b3f22c8839b2b291d79224fddfda0fc9b9b4e13d3918dc298ea3ea8c39e9e83L12-R28) [[6]](diffhunk://#diff-cb6a8121f62c9ce666539df46d5246ec33e5d1eb311666dc858adb3269d806a3R9-R10)
* Refactored threshold logic within each scanner to use the new struct, including dynamic calculation of window durations and reasons. [[1]](diffhunk://#diff-1056de04f7a65e65c42e8f5000f442802b9f16bbcb02b0e80f1cd130e649b4e2L46-R47) [[2]](diffhunk://#diff-46f8cd4cd117cf137843db0591dc1bf0c03524ace3643f60b7aeac5af3aba45fR36-R46) [[3]](diffhunk://#diff-5a144e117422d73d08c93fe203441b426bf71d99bc1f6c554f11210dc8f2f37fL38-R59) [[4]](diffhunk://#diff-d7dcb6c87cc7b0dad8a935ad07cf9f6cdef7939ec9252b7ce35651fe3ff077a7L50-R51) [[5]](diffhunk://#diff-3b3f22c8839b2b291d79224fddfda0fc9b9b4e13d3918dc298ea3ea8c39e9e83L40-R49)

### User Documentation and Usability

* Added `ExampleConfigTOML` in `internal/config/config.go` as a documented schema for users to customize thresholds in their config file.
* Improved help text for CLI flags and ensured that a value of `0` means "flag all", while `-1` means "not set, use config/default".

These changes make threshold management more robust, extensible, and user-friendly, paving the way for future resource types and configuration options.