### PR TITLE
dx: 10 unit tests

### DIFF
--- a/cmd/dig.go
+++ b/cmd/dig.go
@@ -61,25 +61,25 @@ var digCmd = &cobra.Command{
 // defaults -> config.toml -> CLI flags. A flag value of -1 means
 // the user did not set it; 0 is a deliberate "no age check".
 func resolveThresholds(cmd *cobra.Command) config.Thresholds {
-	t := config.LoadThresholds()
-	apply := func(flag string, dst *int) {
-		v, err := cmd.Flags().GetInt(flag)
-		if err != nil || v == -1 {
-			return
-		}
-		*dst = v
+	names := []string{
+		"ec2-stopped-days",
+		"ebs-unattached-days",
+		"snapshot-age-days",
+		"dynamodb-idle-days",
+		"elasticache-idle-days",
+		"nat-idle-days",
+		"s3-multipart-days",
+		"s3-bucket-empty-days",
+		"ecr-image-age-days",
+		"efs-idle-days",
 	}
-	apply("ec2-stopped-days", &t.EC2StoppedDays)
-	apply("ebs-unattached-days", &t.EBSUnattachedDays)
-	apply("snapshot-age-days", &t.SnapshotAgeDays)
-	apply("dynamodb-idle-days", &t.DynamoDBIdleDays)
-	apply("elasticache-idle-days", &t.ElastiCacheIdleDays)
-	apply("nat-idle-days", &t.NATIdleDays)
-	apply("s3-multipart-days", &t.S3MultipartDays)
-	apply("s3-bucket-empty-days", &t.S3BucketEmptyDays)
-	apply("ecr-image-age-days", &t.ECRImageAgeDays)
-	apply("efs-idle-days", &t.EFSIdleDays)
-	return t
+	flags := make(map[string]int, len(names))
+	for _, n := range names {
+		if v, err := cmd.Flags().GetInt(n); err == nil {
+			flags[n] = v
+		}
+	}
+	return config.ResolveThresholds(config.LoadThresholds(), flags)
 }
 
 func init() {

--- a/internal/config/thresholds.go
+++ b/internal/config/thresholds.go
@@ -32,3 +32,29 @@ func DefaultThresholds() Thresholds {
 		CloudWatchIdleDays:  30,
 	}
 }
+
+// ResolveThresholds layers CLI flag values on top of the config-loaded base.
+// A flag value of -1 means the user did not set it, so the base wins; any
+// other value — including 0 — replaces the base.
+func ResolveThresholds(base Thresholds, flags map[string]int) Thresholds {
+	t := base
+	apply := func(name string, dst *int) {
+		v, ok := flags[name]
+		if !ok || v == -1 {
+			return
+		}
+		*dst = v
+	}
+	apply("ec2-stopped-days", &t.EC2StoppedDays)
+	apply("ebs-unattached-days", &t.EBSUnattachedDays)
+	apply("snapshot-age-days", &t.SnapshotAgeDays)
+	apply("dynamodb-idle-days", &t.DynamoDBIdleDays)
+	apply("elasticache-idle-days", &t.ElastiCacheIdleDays)
+	apply("nat-idle-days", &t.NATIdleDays)
+	apply("s3-multipart-days", &t.S3MultipartDays)
+	apply("s3-bucket-empty-days", &t.S3BucketEmptyDays)
+	apply("ecr-image-age-days", &t.ECRImageAgeDays)
+	apply("efs-idle-days", &t.EFSIdleDays)
+	apply("cloudwatch-idle-days", &t.CloudWatchIdleDays)
+	return t
+}

--- a/internal/config/thresholds_test.go
+++ b/internal/config/thresholds_test.go
@@ -1,0 +1,142 @@
+package config
+
+import "testing"
+
+func TestDefaultThresholds_Values(t *testing.T) {
+	got := DefaultThresholds()
+	want := Thresholds{
+		EC2StoppedDays:      7,
+		EBSUnattachedDays:   0,
+		SnapshotAgeDays:     90,
+		DynamoDBIdleDays:    14,
+		ElastiCacheIdleDays: 7,
+		NATIdleDays:         7,
+		S3MultipartDays:     7,
+		S3BucketEmptyDays:   30,
+		ECRImageAgeDays:     180,
+		EFSIdleDays:         7,
+		CloudWatchIdleDays:  30,
+	}
+	if got != want {
+		t.Errorf("DefaultThresholds() = %+v, want %+v", got, want)
+	}
+}
+
+// The EBSUnattachedDays default is intentionally 0 ("flag every unattached
+// volume regardless of age"). This test asserts every *other* field is
+// non-zero so a future refactor can't silently collapse a meaningful default
+// to the struct zero value.
+func TestDefaultThresholds_NonZeroFields(t *testing.T) {
+	d := DefaultThresholds()
+	cases := []struct {
+		name string
+		v    int
+	}{
+		{"EC2StoppedDays", d.EC2StoppedDays},
+		{"SnapshotAgeDays", d.SnapshotAgeDays},
+		{"DynamoDBIdleDays", d.DynamoDBIdleDays},
+		{"ElastiCacheIdleDays", d.ElastiCacheIdleDays},
+		{"NATIdleDays", d.NATIdleDays},
+		{"S3MultipartDays", d.S3MultipartDays},
+		{"S3BucketEmptyDays", d.S3BucketEmptyDays},
+		{"ECRImageAgeDays", d.ECRImageAgeDays},
+		{"EFSIdleDays", d.EFSIdleDays},
+		{"CloudWatchIdleDays", d.CloudWatchIdleDays},
+	}
+	for _, c := range cases {
+		if c.v == 0 {
+			t.Errorf("%s default is zero; expected a positive number of days", c.name)
+		}
+	}
+}
+
+func TestResolveThresholds_NoFlagsReturnsBase(t *testing.T) {
+	base := DefaultThresholds()
+	got := ResolveThresholds(base, nil)
+	if got != base {
+		t.Errorf("ResolveThresholds(base, nil) = %+v, want %+v", got, base)
+	}
+}
+
+func TestResolveThresholds_ConfigValueFlowsThrough(t *testing.T) {
+	// A config-loaded base with a non-default value should survive when no
+	// CLI flag is provided for that key.
+	base := DefaultThresholds()
+	base.EC2StoppedDays = 42
+	got := ResolveThresholds(base, map[string]int{})
+	if got.EC2StoppedDays != 42 {
+		t.Errorf("config value lost: got %d, want 42", got.EC2StoppedDays)
+	}
+}
+
+func TestResolveThresholds_FlagMinusOneDoesNotOverride(t *testing.T) {
+	base := DefaultThresholds()
+	base.EC2StoppedDays = 42
+	got := ResolveThresholds(base, map[string]int{"ec2-stopped-days": -1})
+	if got.EC2StoppedDays != 42 {
+		t.Errorf("-1 flag wrongly overrode config: got %d, want 42", got.EC2StoppedDays)
+	}
+}
+
+func TestResolveThresholds_FlagZeroOverridesConfig(t *testing.T) {
+	// 0 is a deliberate "no age check" — it must replace the config value.
+	base := DefaultThresholds()
+	base.EC2StoppedDays = 42
+	got := ResolveThresholds(base, map[string]int{"ec2-stopped-days": 0})
+	if got.EC2StoppedDays != 0 {
+		t.Errorf("0 flag did not override: got %d, want 0", got.EC2StoppedDays)
+	}
+}
+
+func TestResolveThresholds_LargeFlagOverridesConfig(t *testing.T) {
+	base := DefaultThresholds()
+	base.EC2StoppedDays = 42
+	got := ResolveThresholds(base, map[string]int{"ec2-stopped-days": 99999})
+	if got.EC2StoppedDays != 99999 {
+		t.Errorf("large flag did not override: got %d, want 99999", got.EC2StoppedDays)
+	}
+}
+
+func TestResolveThresholds_ZeroStaysZero(t *testing.T) {
+	// Caller passed 0 (intentional no-age) — ResolveThresholds must not
+	// treat it as "missing" and fall back to a default.
+	base := Thresholds{EC2StoppedDays: 0}
+	got := ResolveThresholds(base, nil)
+	if got.EC2StoppedDays != 0 {
+		t.Errorf("zero replaced: got %d, want 0", got.EC2StoppedDays)
+	}
+}
+
+func TestResolveThresholds_AllFlagsRouteToCorrectField(t *testing.T) {
+	// Guards against silent bugs like mapping "nat-idle-days" to EFSIdleDays.
+	flags := map[string]int{
+		"ec2-stopped-days":      1,
+		"ebs-unattached-days":   2,
+		"snapshot-age-days":     3,
+		"dynamodb-idle-days":    4,
+		"elasticache-idle-days": 5,
+		"nat-idle-days":         6,
+		"s3-multipart-days":     7,
+		"s3-bucket-empty-days":  8,
+		"ecr-image-age-days":    9,
+		"efs-idle-days":         10,
+		"cloudwatch-idle-days":  11,
+	}
+	got := ResolveThresholds(Thresholds{}, flags)
+	want := Thresholds{
+		EC2StoppedDays:      1,
+		EBSUnattachedDays:   2,
+		SnapshotAgeDays:     3,
+		DynamoDBIdleDays:    4,
+		ElastiCacheIdleDays: 5,
+		NATIdleDays:         6,
+		S3MultipartDays:     7,
+		S3BucketEmptyDays:   8,
+		ECRImageAgeDays:     9,
+		EFSIdleDays:         10,
+		CloudWatchIdleDays:  11,
+	}
+	if got != want {
+		t.Errorf("ResolveThresholds per-field routing wrong:\n got=%+v\nwant=%+v", got, want)
+	}
+}

--- a/internal/output/table_test.go
+++ b/internal/output/table_test.go
@@ -1,0 +1,137 @@
+package output
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/yehorkochetov/rey/internal/scanner"
+)
+
+// captureStdout redirects os.Stdout for the duration of fn and returns
+// everything written. RenderGraveyard writes directly to stdout, so tests
+// must intercept the fd rather than inspect a return value.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	done := make(chan struct{})
+	var buf bytes.Buffer
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+
+	fn()
+
+	_ = w.Close()
+	os.Stdout = orig
+	<-done
+	return buf.String()
+}
+
+func TestRenderGraveyard_EmptyShowsPlaceholder(t *testing.T) {
+	out := captureStdout(t, func() {
+		RenderGraveyard(nil)
+	})
+	if !strings.Contains(out, "No wasted resources found") {
+		t.Errorf("expected empty-state placeholder, got: %q", out)
+	}
+}
+
+func TestRenderGraveyard_SingleRendersWithoutPanic(t *testing.T) {
+	res := []scanner.DeadResource{
+		{Type: "EIP", ID: "eipalloc-1", Region: "us-east-1", MonthlyCost: 3.60},
+	}
+	defer func() {
+		if p := recover(); p != nil {
+			t.Fatalf("render panicked: %v", p)
+		}
+	}()
+	out := captureStdout(t, func() { RenderGraveyard(res) })
+	if out == "" {
+		t.Error("expected non-empty output for a single resource")
+	}
+}
+
+func TestRenderGraveyard_MultipleRendersWithoutPanic(t *testing.T) {
+	res := []scanner.DeadResource{
+		{Type: "EIP", ID: "eipalloc-1", Region: "us-east-1", MonthlyCost: 3.60},
+		{Type: "EBSVolume", ID: "vol-2", Region: "us-east-1", MonthlyCost: 10.00},
+		{Type: "NATGateway", ID: "nat-3", Region: "us-east-1", MonthlyCost: 32.40},
+	}
+	defer func() {
+		if p := recover(); p != nil {
+			t.Fatalf("render panicked: %v", p)
+		}
+	}()
+	_ = captureStdout(t, func() { RenderGraveyard(res) })
+}
+
+func TestRenderGraveyard_TotalCostSums(t *testing.T) {
+	// $3.60 + $10.00 = $13.60 — the footer string is load-bearing.
+	res := []scanner.DeadResource{
+		{Type: "EIP", ID: "eipalloc-1", Region: "us-east-1", MonthlyCost: 3.60},
+		{Type: "EBSVolume", ID: "vol-2", Region: "us-east-1", MonthlyCost: 10.00},
+	}
+	out := captureStdout(t, func() { RenderGraveyard(res) })
+	if !strings.Contains(out, "$13.60") {
+		t.Errorf("expected total $13.60 in footer, got: %q", out)
+	}
+	if !strings.Contains(out, "2 resources") {
+		t.Errorf("expected footer to mention 2 resources, got: %q", out)
+	}
+}
+
+func TestCostStyle(t *testing.T) {
+	// lipgloss.TerminalColor doesn't offer equality, but the underlying
+	// lipgloss.Color is a string — fmt.Sprintf gives a stable comparable
+	// key across all TerminalColor implementations.
+	fgOf := func(cost float64) string { return fgKey(costStyle(cost)) }
+
+	cases := []struct {
+		name string
+		cost float64
+		want string
+	}{
+		{"10.01 gets red (high cost)", 10.01, fgKey(highCost)},
+		{"1.01 gets yellow (medium cost)", 1.01, fgKey(medCost)},
+		{"0.50 gets default style", 0.50, fgKey(defaultCost)},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := fgOf(c.cost); got != c.want {
+				t.Errorf("costStyle(%v) foreground = %q, want %q", c.cost, got, c.want)
+			}
+		})
+	}
+}
+
+func TestCostStyle_Boundaries(t *testing.T) {
+	// Boundaries in costStyle are strictly ">": 10 lands in the medium
+	// bucket, 1 lands in the default bucket. Pin this so a stray >=
+	// can't silently shift colors for cut-off-priced resources.
+	if fgKey(costStyle(10)) == fgKey(highCost) {
+		t.Error("cost == 10 should NOT be red (boundary is strictly > 10)")
+	}
+	if fgKey(costStyle(1)) == fgKey(medCost) {
+		t.Error("cost == 1 should NOT be yellow (boundary is strictly > 1)")
+	}
+}
+
+// fgKey returns a comparable string key for a style's foreground color.
+// Lipgloss's TerminalColor interface isn't directly comparable, but the
+// concrete Color/NoColor types print distinctly under %#v — good enough
+// to tell "which style did costStyle return" in a test.
+func fgKey(s lipgloss.Style) string {
+	return fmt.Sprintf("%#v", s.GetForeground())
+}

--- a/internal/scanner/ebs.go
+++ b/internal/scanner/ebs.go
@@ -33,57 +33,68 @@ func (e *EBSScanner) Scan(ctx context.Context, cfg aws.Config, t config.Threshol
 		return nil, fmt.Errorf("describe volumes: %w", err)
 	}
 
-	minAge := time.Duration(t.EBSUnattachedDays) * 24 * time.Hour
-	var results []DeadResource
 	now := time.Now().UTC()
+	var results []DeadResource
 	for _, v := range out.Volumes {
-		var age time.Duration
-		if v.CreateTime != nil {
-			age = now.Sub(*v.CreateTime)
+		if r, ok := considerEBSVolume(v, now, t, cfg.Region); ok {
+			results = append(results, r)
 		}
-		if t.EBSUnattachedDays > 0 && age < minAge {
-			continue
-		}
-
-		tags := make(map[string]string)
-		var name string
-		for _, t := range v.Tags {
-			k := aws.ToString(t.Key)
-			val := aws.ToString(t.Value)
-			tags[k] = val
-			if k == "Name" {
-				name = val
-			}
-		}
-		id := aws.ToString(v.VolumeId)
-		if name == "" {
-			name = id
-		}
-		var size int32
-		if v.Size != nil {
-			size = *v.Size
-		}
-
-		reason := "Unattached"
-		if age > 0 {
-			reason = fmt.Sprintf("Unattached for %d days", int(age.Hours()/24))
-		}
-
-		results = append(results, DeadResource{
-			Type:        "EBSVolume",
-			ID:          id,
-			Name:        name,
-			Region:      cfg.Region,
-			Age:         age,
-			MonthlyCost: float64(size) * 0.10,
-			Reason:      reason,
-			Tags:        tags,
-		})
 	}
-
 	return results, nil
 }
 
 func (e *EBSScanner) EstimateCost(r DeadResource) float64 {
 	return r.MonthlyCost
+}
+
+// considerEBSVolume is the pure decision helper used by EBSScanner. It takes
+// an already-filtered "available" volume, the current time, and the active
+// thresholds, and returns the DeadResource plus whether the volume should be
+// flagged. A threshold of 0 disables the age check entirely.
+func considerEBSVolume(v ec2types.Volume, now time.Time, t config.Thresholds, region string) (DeadResource, bool) {
+	var age time.Duration
+	if v.CreateTime != nil {
+		age = now.Sub(*v.CreateTime)
+	}
+	if t.EBSUnattachedDays > 0 {
+		minAge := time.Duration(t.EBSUnattachedDays) * 24 * time.Hour
+		if age < minAge {
+			return DeadResource{}, false
+		}
+	}
+
+	tags := make(map[string]string)
+	var name string
+	for _, tag := range v.Tags {
+		k := aws.ToString(tag.Key)
+		val := aws.ToString(tag.Value)
+		tags[k] = val
+		if k == "Name" {
+			name = val
+		}
+	}
+	id := aws.ToString(v.VolumeId)
+	if name == "" {
+		name = id
+	}
+	var size int32
+	if v.Size != nil {
+		size = *v.Size
+	}
+
+	reason := "Unattached"
+	if age > 0 {
+		reason = fmt.Sprintf("Unattached for %d days", int(age.Hours()/24))
+	}
+
+	return DeadResource{
+		Type:        "EBSVolume",
+		ID:          id,
+		Name:        name,
+		Region:      region,
+		Age:         age,
+		MonthlyCost: float64(size) * 0.10,
+		Reason:      reason,
+		Tags:        tags,
+	}, true
 }

--- a/internal/scanner/ebs_test.go
+++ b/internal/scanner/ebs_test.go
@@ -1,0 +1,89 @@
+package scanner
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/yehorkochetov/rey/internal/config"
+)
+
+func TestConsiderEBSVolume_AgeThreshold(t *testing.T) {
+	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name          string
+		createdDaysBack int
+		threshold     int
+		wantFlagged   bool
+	}{
+		{"newer than threshold is skipped", 3, 7, false},
+		{"exactly at threshold is flagged", 7, 7, true},
+		{"older than threshold is flagged", 30, 7, true},
+		{"threshold 0 flags any age", 1, 0, true},
+		{"threshold 0 flags zero age", 0, 0, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			created := now.Add(-time.Duration(c.createdDaysBack) * 24 * time.Hour)
+			v := ec2types.Volume{
+				VolumeId:   aws.String("vol-test"),
+				CreateTime: &created,
+				Size:       aws.Int32(10),
+			}
+			_, ok := considerEBSVolume(v, now, config.Thresholds{EBSUnattachedDays: c.threshold}, "us-east-1")
+			if ok != c.wantFlagged {
+				t.Errorf("flagged=%v, want %v", ok, c.wantFlagged)
+			}
+		})
+	}
+}
+
+func TestConsiderEBSVolume_CostFromSize(t *testing.T) {
+	now := time.Now().UTC()
+	created := now.Add(-30 * 24 * time.Hour)
+	cases := []struct {
+		name    string
+		sizeGB  int32
+		wantUSD float64
+	}{
+		{"100GB at $0.10/GB", 100, 10.00},
+		{"1GB", 1, 0.10},
+		{"500GB", 500, 50.00},
+		{"0GB (nil-like)", 0, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			v := ec2types.Volume{
+				VolumeId:   aws.String("vol-cost"),
+				CreateTime: &created,
+				Size:       aws.Int32(c.sizeGB),
+			}
+			r, ok := considerEBSVolume(v, now, config.Thresholds{EBSUnattachedDays: 0}, "us-east-1")
+			if !ok {
+				t.Fatal("expected flagged")
+			}
+			if r.MonthlyCost != c.wantUSD {
+				t.Errorf("cost=%.4f, want %.4f", r.MonthlyCost, c.wantUSD)
+			}
+		})
+	}
+}
+
+func TestConsiderEBSVolume_NilSizeIsSafe(t *testing.T) {
+	now := time.Now().UTC()
+	created := now.Add(-30 * 24 * time.Hour)
+	v := ec2types.Volume{
+		VolumeId:   aws.String("vol-nil-size"),
+		CreateTime: &created,
+		Size:       nil,
+	}
+	r, ok := considerEBSVolume(v, now, config.Thresholds{EBSUnattachedDays: 0}, "us-east-1")
+	if !ok {
+		t.Fatal("expected flagged")
+	}
+	if r.MonthlyCost != 0 {
+		t.Errorf("cost with nil size = %v, want 0", r.MonthlyCost)
+	}
+}

--- a/internal/scanner/ec2.go
+++ b/internal/scanner/ec2.go
@@ -20,7 +20,6 @@ func (e *EC2Scanner) Name() string {
 }
 
 func (e *EC2Scanner) Scan(ctx context.Context, cfg aws.Config, t config.Thresholds) ([]DeadResource, error) {
-	minAge := time.Duration(t.EC2StoppedDays) * 24 * time.Hour
 	client := ec2.NewFromConfig(cfg)
 
 	out, err := client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
@@ -35,49 +34,63 @@ func (e *EC2Scanner) Scan(ctx context.Context, cfg aws.Config, t config.Threshol
 		return nil, fmt.Errorf("describe instances: %w", err)
 	}
 
-	var results []DeadResource
 	now := time.Now().UTC()
+	var results []DeadResource
 	for _, res := range out.Reservations {
 		for _, inst := range res.Instances {
-			stopTime, ok := parseStopTime(aws.ToString(inst.StateTransitionReason))
-			if !ok {
-				continue
+			if r, ok := considerEC2Instance(inst, now, t, cfg.Region); ok {
+				results = append(results, r)
 			}
-			age := now.Sub(stopTime)
-			if t.EC2StoppedDays > 0 && age < minAge {
-				continue
-			}
+		}
+	}
+	return results, nil
+}
 
-			tags := make(map[string]string)
-			var name string
-			for _, t := range inst.Tags {
-				k := aws.ToString(t.Key)
-				v := aws.ToString(t.Value)
-				tags[k] = v
-				if k == "Name" {
-					name = v
-				}
-			}
-			id := aws.ToString(inst.InstanceId)
-			if name == "" {
-				name = id
-			}
-			days := int(age.Hours() / 24)
-
-			results = append(results, DeadResource{
-				Type:        "EC2Instance",
-				ID:          id,
-				Name:        name,
-				Region:      cfg.Region,
-				Age:         age,
-				MonthlyCost: 0,
-				Reason:      fmt.Sprintf("Stopped for %d days, attached EBS still charging", days),
-				Tags:        tags,
-			})
+// considerEC2Instance decides whether a single instance should be flagged.
+// Only stopped instances with a parseable stop timestamp qualify; any other
+// state is skipped even if callers forget to apply the API-level filter.
+func considerEC2Instance(inst ec2types.Instance, now time.Time, t config.Thresholds, region string) (DeadResource, bool) {
+	if inst.State == nil || inst.State.Name != ec2types.InstanceStateNameStopped {
+		return DeadResource{}, false
+	}
+	stopTime, ok := parseStopTime(aws.ToString(inst.StateTransitionReason))
+	if !ok {
+		return DeadResource{}, false
+	}
+	age := now.Sub(stopTime)
+	if t.EC2StoppedDays > 0 {
+		minAge := time.Duration(t.EC2StoppedDays) * 24 * time.Hour
+		if age < minAge {
+			return DeadResource{}, false
 		}
 	}
 
-	return results, nil
+	tags := make(map[string]string)
+	var name string
+	for _, tag := range inst.Tags {
+		k := aws.ToString(tag.Key)
+		v := aws.ToString(tag.Value)
+		tags[k] = v
+		if k == "Name" {
+			name = v
+		}
+	}
+	id := aws.ToString(inst.InstanceId)
+	if name == "" {
+		name = id
+	}
+	days := int(age.Hours() / 24)
+
+	return DeadResource{
+		Type:        "EC2Instance",
+		ID:          id,
+		Name:        name,
+		Region:      region,
+		Age:         age,
+		MonthlyCost: 0,
+		Reason:      fmt.Sprintf("Stopped for %d days, attached EBS still charging", days),
+		Tags:        tags,
+	}, true
 }
 
 func (e *EC2Scanner) EstimateCost(r DeadResource) float64 {

--- a/internal/scanner/ec2_test.go
+++ b/internal/scanner/ec2_test.go
@@ -1,0 +1,87 @@
+package scanner
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/yehorkochetov/rey/internal/config"
+)
+
+// stopReason builds the EC2 StateTransitionReason string format that
+// parseStopTime expects: "User initiated (YYYY-MM-DD HH:MM:SS GMT)".
+func stopReason(stoppedAt time.Time) string {
+	return fmt.Sprintf("User initiated (%s GMT)", stoppedAt.Format("2006-01-02 15:04:05"))
+}
+
+func TestConsiderEC2Instance_RunningNeverFlagged(t *testing.T) {
+	// Even if the API filter slipped a running instance through, the pure
+	// filter must reject it.
+	inst := ec2types.Instance{
+		InstanceId:            aws.String("i-running"),
+		State:                 &ec2types.InstanceState{Name: ec2types.InstanceStateNameRunning},
+		StateTransitionReason: aws.String(stopReason(time.Now().UTC().Add(-30 * 24 * time.Hour))),
+	}
+	_, ok := considerEC2Instance(inst, time.Now().UTC(), config.Thresholds{EC2StoppedDays: 7}, "us-east-1")
+	if ok {
+		t.Error("running instance must never be flagged")
+	}
+}
+
+func TestConsiderEC2Instance_StoppedAgeThreshold(t *testing.T) {
+	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name         string
+		stoppedDays  int
+		threshold    int
+		wantFlagged  bool
+	}{
+		{"stopped 2 days, threshold 7: skipped", 2, 7, false},
+		{"stopped 7 days, threshold 7: flagged", 7, 7, true},
+		{"stopped 30 days, threshold 7: flagged", 30, 7, true},
+		{"threshold 0 flags regardless of age", 1, 0, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			stoppedAt := now.Add(-time.Duration(c.stoppedDays) * 24 * time.Hour)
+			inst := ec2types.Instance{
+				InstanceId:            aws.String("i-test"),
+				State:                 &ec2types.InstanceState{Name: ec2types.InstanceStateNameStopped},
+				StateTransitionReason: aws.String(stopReason(stoppedAt)),
+			}
+			_, ok := considerEC2Instance(inst, now, config.Thresholds{EC2StoppedDays: c.threshold}, "us-east-1")
+			if ok != c.wantFlagged {
+				t.Errorf("flagged=%v, want %v", ok, c.wantFlagged)
+			}
+		})
+	}
+}
+
+func TestConsiderEC2Instance_UnparseableStopReasonSkipped(t *testing.T) {
+	// Instances stopped by the scheduler, or older AWS API formats, may
+	// lack a parseable timestamp. We can't compute age, so we skip rather
+	// than treat as age=0 and flag everything.
+	inst := ec2types.Instance{
+		InstanceId:            aws.String("i-weird"),
+		State:                 &ec2types.InstanceState{Name: ec2types.InstanceStateNameStopped},
+		StateTransitionReason: aws.String("Server.ScheduledStop"),
+	}
+	_, ok := considerEC2Instance(inst, time.Now().UTC(), config.Thresholds{EC2StoppedDays: 0}, "us-east-1")
+	if ok {
+		t.Error("instance with unparseable StateTransitionReason should be skipped")
+	}
+}
+
+func TestConsiderEC2Instance_NilStateSkipped(t *testing.T) {
+	inst := ec2types.Instance{
+		InstanceId: aws.String("i-no-state"),
+		State:      nil,
+	}
+	_, ok := considerEC2Instance(inst, time.Now().UTC(), config.Thresholds{EC2StoppedDays: 0}, "us-east-1")
+	if ok {
+		t.Error("instance with nil State should be skipped")
+	}
+}

--- a/internal/scanner/security_group.go
+++ b/internal/scanner/security_group.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
 	"github.com/yehorkochetov/rey/internal/config"
 )
@@ -38,34 +39,42 @@ func (s *SecurityGroupScanner) Scan(ctx context.Context, cfg aws.Config, _ confi
 
 	var results []DeadResource
 	for _, g := range groups.SecurityGroups {
-		name := aws.ToString(g.GroupName)
-		if name == "default" {
-			continue
+		if r, ok := considerSecurityGroup(g, inUse, cfg.Region); ok {
+			results = append(results, r)
 		}
-		id := aws.ToString(g.GroupId)
-		if _, used := inUse[id]; used {
-			continue
-		}
-
-		tags := make(map[string]string)
-		for _, t := range g.Tags {
-			tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
-		}
-
-		results = append(results, DeadResource{
-			Type:        "SecurityGroup",
-			ID:          id,
-			Name:        name,
-			Region:      cfg.Region,
-			MonthlyCost: 0,
-			Reason:      "Not attached to any resource",
-			Tags:        tags,
-		})
 	}
-
 	return results, nil
 }
 
 func (s *SecurityGroupScanner) EstimateCost(r DeadResource) float64 {
 	return 0
+}
+
+// considerSecurityGroup is the pure filter for security groups. The
+// "default" group is untouched — AWS creates one per VPC and it can't be
+// deleted. Any other group is flagged when no ENI references it.
+func considerSecurityGroup(g ec2types.SecurityGroup, inUse map[string]struct{}, region string) (DeadResource, bool) {
+	name := aws.ToString(g.GroupName)
+	if name == "default" {
+		return DeadResource{}, false
+	}
+	id := aws.ToString(g.GroupId)
+	if _, used := inUse[id]; used {
+		return DeadResource{}, false
+	}
+
+	tags := make(map[string]string)
+	for _, tag := range g.Tags {
+		tags[aws.ToString(tag.Key)] = aws.ToString(tag.Value)
+	}
+
+	return DeadResource{
+		Type:        "SecurityGroup",
+		ID:          id,
+		Name:        name,
+		Region:      region,
+		MonthlyCost: 0,
+		Reason:      "Not attached to any resource",
+		Tags:        tags,
+	}, true
 }

--- a/internal/scanner/security_group_test.go
+++ b/internal/scanner/security_group_test.go
@@ -1,0 +1,67 @@
+package scanner
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+func TestConsiderSecurityGroup_DefaultGroupSkipped(t *testing.T) {
+	g := ec2types.SecurityGroup{
+		GroupId:   aws.String("sg-default"),
+		GroupName: aws.String("default"),
+	}
+	_, ok := considerSecurityGroup(g, nil, "us-east-1")
+	if ok {
+		t.Error(`security group named "default" must never be flagged`)
+	}
+}
+
+func TestConsiderSecurityGroup_AttachedToENISkipped(t *testing.T) {
+	g := ec2types.SecurityGroup{
+		GroupId:   aws.String("sg-123"),
+		GroupName: aws.String("my-app"),
+	}
+	inUse := map[string]struct{}{"sg-123": {}}
+	_, ok := considerSecurityGroup(g, inUse, "us-east-1")
+	if ok {
+		t.Error("group attached to at least one ENI must not be flagged")
+	}
+}
+
+func TestConsiderSecurityGroup_UnattachedIsFlagged(t *testing.T) {
+	g := ec2types.SecurityGroup{
+		GroupId:   aws.String("sg-orphan"),
+		GroupName: aws.String("my-unused"),
+		Tags: []ec2types.Tag{
+			{Key: aws.String("Name"), Value: aws.String("unused-sg")},
+		},
+	}
+	r, ok := considerSecurityGroup(g, map[string]struct{}{"sg-other": {}}, "us-east-1")
+	if !ok {
+		t.Fatal("unattached non-default group should be flagged")
+	}
+	if r.Type != "SecurityGroup" {
+		t.Errorf("Type = %q, want SecurityGroup", r.Type)
+	}
+	if r.ID != "sg-orphan" {
+		t.Errorf("ID = %q, want sg-orphan", r.ID)
+	}
+	if r.MonthlyCost != 0 {
+		t.Errorf("cost = %v, want 0 (security groups are free)", r.MonthlyCost)
+	}
+}
+
+func TestConsiderSecurityGroup_NilInUseMap(t *testing.T) {
+	// Defensive: if the scanner hasn't populated inUse (e.g. no ENIs exist)
+	// passing nil must still work.
+	g := ec2types.SecurityGroup{
+		GroupId:   aws.String("sg-1"),
+		GroupName: aws.String("foo"),
+	}
+	_, ok := considerSecurityGroup(g, nil, "us-east-1")
+	if !ok {
+		t.Error("with nil inUse map, non-default group should be flagged")
+	}
+}

--- a/internal/scanner/snapshot.go
+++ b/internal/scanner/snapshot.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
 	"github.com/yehorkochetov/rey/internal/config"
 )
@@ -18,7 +19,6 @@ func (s *SnapshotScanner) Name() string {
 }
 
 func (s *SnapshotScanner) Scan(ctx context.Context, cfg aws.Config, t config.Thresholds) ([]DeadResource, error) {
-	minAge := time.Duration(t.SnapshotAgeDays) * 24 * time.Hour
 	client := ec2.NewFromConfig(cfg)
 
 	images, err := client.DescribeImages(ctx, &ec2.DescribeImagesInput{
@@ -45,46 +45,57 @@ func (s *SnapshotScanner) Scan(ctx context.Context, cfg aws.Config, t config.Thr
 		return nil, fmt.Errorf("describe snapshots: %w", err)
 	}
 
-	var results []DeadResource
 	now := time.Now().UTC()
+	var results []DeadResource
 	for _, snap := range snaps.Snapshots {
-		id := aws.ToString(snap.SnapshotId)
-		if _, used := amiSnapshots[id]; used {
-			continue
+		if r, ok := considerSnapshot(snap, amiSnapshots, now, t, cfg.Region); ok {
+			results = append(results, r)
 		}
-		if snap.StartTime == nil {
-			continue
-		}
-		age := now.Sub(*snap.StartTime)
-		if t.SnapshotAgeDays > 0 && age < minAge {
-			continue
-		}
-
-		tags := make(map[string]string)
-		for _, t := range snap.Tags {
-			tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
-		}
-		var size int32
-		if snap.VolumeSize != nil {
-			size = *snap.VolumeSize
-		}
-
-		results = append(results, DeadResource{
-			Type:        "EBSSnapshot",
-			ID:          id,
-			Region:      cfg.Region,
-			Age:         age,
-			MonthlyCost: float64(size) * 0.05,
-			Reason:      snapshotReason(t.SnapshotAgeDays),
-			Tags:        tags,
-		})
 	}
-
 	return results, nil
 }
 
 func (s *SnapshotScanner) EstimateCost(r DeadResource) float64 {
 	return r.MonthlyCost
+}
+
+// considerSnapshot decides whether a single snapshot should be flagged.
+// Snapshots referenced by any AMI are always skipped. A threshold of 0
+// means "flag any snapshot with no AMI reference regardless of age".
+func considerSnapshot(snap ec2types.Snapshot, amiSnapshots map[string]struct{}, now time.Time, t config.Thresholds, region string) (DeadResource, bool) {
+	id := aws.ToString(snap.SnapshotId)
+	if _, used := amiSnapshots[id]; used {
+		return DeadResource{}, false
+	}
+	if snap.StartTime == nil {
+		return DeadResource{}, false
+	}
+	age := now.Sub(*snap.StartTime)
+	if t.SnapshotAgeDays > 0 {
+		minAge := time.Duration(t.SnapshotAgeDays) * 24 * time.Hour
+		if age < minAge {
+			return DeadResource{}, false
+		}
+	}
+
+	tags := make(map[string]string)
+	for _, tag := range snap.Tags {
+		tags[aws.ToString(tag.Key)] = aws.ToString(tag.Value)
+	}
+	var size int32
+	if snap.VolumeSize != nil {
+		size = *snap.VolumeSize
+	}
+
+	return DeadResource{
+		Type:        "EBSSnapshot",
+		ID:          id,
+		Region:      region,
+		Age:         age,
+		MonthlyCost: float64(size) * 0.05,
+		Reason:      snapshotReason(t.SnapshotAgeDays),
+		Tags:        tags,
+	}, true
 }
 
 func snapshotReason(days int) string {

--- a/internal/scanner/snapshot_test.go
+++ b/internal/scanner/snapshot_test.go
@@ -1,0 +1,87 @@
+package scanner
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/yehorkochetov/rey/internal/config"
+)
+
+func TestConsiderSnapshot_AgeThreshold(t *testing.T) {
+	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name            string
+		startedDaysBack int
+		threshold       int
+		wantFlagged     bool
+	}{
+		{"newer than 90d skipped", 30, 90, false},
+		{"exactly 90d flagged", 90, 90, true},
+		{"older than 90d flagged", 365, 90, true},
+		{"threshold 0 flags any age", 1, 0, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			start := now.Add(-time.Duration(c.startedDaysBack) * 24 * time.Hour)
+			snap := ec2types.Snapshot{
+				SnapshotId: aws.String("snap-test"),
+				StartTime:  &start,
+				VolumeSize: aws.Int32(10),
+			}
+			_, ok := considerSnapshot(snap, nil, now, config.Thresholds{SnapshotAgeDays: c.threshold}, "us-east-1")
+			if ok != c.wantFlagged {
+				t.Errorf("flagged=%v, want %v", ok, c.wantFlagged)
+			}
+		})
+	}
+}
+
+func TestConsiderSnapshot_AMIReferenceNeverFlagged(t *testing.T) {
+	now := time.Now().UTC()
+	start := now.Add(-365 * 24 * time.Hour) // very old — would otherwise flag
+	snap := ec2types.Snapshot{
+		SnapshotId: aws.String("snap-used-by-ami"),
+		StartTime:  &start,
+		VolumeSize: aws.Int32(10),
+	}
+	amiSnapshots := map[string]struct{}{"snap-used-by-ami": {}}
+	_, ok := considerSnapshot(snap, amiSnapshots, now, config.Thresholds{SnapshotAgeDays: 90}, "us-east-1")
+	if ok {
+		t.Error("snapshot referenced by AMI should never be flagged")
+	}
+}
+
+func TestConsiderSnapshot_UnreferencedIsFlagged(t *testing.T) {
+	now := time.Now().UTC()
+	start := now.Add(-200 * 24 * time.Hour)
+	snap := ec2types.Snapshot{
+		SnapshotId: aws.String("snap-orphan"),
+		StartTime:  &start,
+		VolumeSize: aws.Int32(20),
+	}
+	// amiSnapshots contains a different id — this snapshot is unreferenced.
+	amiSnapshots := map[string]struct{}{"snap-other": {}}
+	r, ok := considerSnapshot(snap, amiSnapshots, now, config.Thresholds{SnapshotAgeDays: 90}, "us-east-1")
+	if !ok {
+		t.Fatal("unreferenced old snapshot should be flagged")
+	}
+	if r.Type != "EBSSnapshot" {
+		t.Errorf("Type = %q, want EBSSnapshot", r.Type)
+	}
+}
+
+func TestConsiderSnapshot_NilStartTimeSkipped(t *testing.T) {
+	// An AWS snapshot with no StartTime is malformed — we skip it rather
+	// than treat it as infinitely old.
+	snap := ec2types.Snapshot{
+		SnapshotId: aws.String("snap-no-time"),
+		StartTime:  nil,
+	}
+	_, ok := considerSnapshot(snap, nil, time.Now().UTC(), config.Thresholds{SnapshotAgeDays: 0}, "us-east-1")
+	if ok {
+		t.Error("snapshot with nil StartTime should be skipped")
+	}
+}

--- a/internal/scanner/types.go
+++ b/internal/scanner/types.go
@@ -39,3 +39,30 @@ func idleReason(prefix string, days int) string {
 	}
 	return fmt.Sprintf("%s in %d days", prefix, days)
 }
+
+// FormatAge renders Age as a human-readable duration — days when the age
+// exceeds 24h, hours otherwise. Singular/plural units are honored so the
+// CLI shows "1 day" rather than "1 days". A zero or negative Age returns
+// "-" so the table doesn't show a meaningless "0 hours".
+func (r DeadResource) FormatAge() string {
+	if r.Age <= 0 {
+		return "-"
+	}
+	days := int(r.Age.Hours() / 24)
+	if days >= 1 {
+		if days == 1 {
+			return "1 day"
+		}
+		return fmt.Sprintf("%d days", days)
+	}
+	hours := int(r.Age.Hours())
+	if hours == 1 {
+		return "1 hour"
+	}
+	return fmt.Sprintf("%d hours", hours)
+}
+
+// FormatCost renders MonthlyCost as "$X.XX".
+func (r DeadResource) FormatCost() string {
+	return fmt.Sprintf("$%.2f", r.MonthlyCost)
+}

--- a/internal/scanner/types_test.go
+++ b/internal/scanner/types_test.go
@@ -1,0 +1,97 @@
+package scanner
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatAge(t *testing.T) {
+	cases := []struct {
+		name string
+		age  time.Duration
+		want string
+	}{
+		{"7 days", 7 * 24 * time.Hour, "7 days"},
+		{"1 day", 24 * time.Hour, "1 day"},
+		{"exactly 2 days", 48 * time.Hour, "2 days"},
+		{"12 hours", 12 * time.Hour, "12 hours"},
+		{"1 hour", 1 * time.Hour, "1 hour"},
+		{"0 duration renders as dash", 0, "-"},
+		{"negative duration renders as dash", -1 * time.Hour, "-"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := DeadResource{Age: c.age}
+			got := r.FormatAge()
+			if got != c.want {
+				t.Errorf("FormatAge(%v) = %q, want %q", c.age, got, c.want)
+			}
+		})
+	}
+}
+
+// Guard against a regression where Go's default time.Duration String() leaks
+// into the UI — the renderer must not show "168h0m0s" for a week-old resource.
+func TestFormatAge_DoesNotLeakDurationString(t *testing.T) {
+	r := DeadResource{Age: 7 * 24 * time.Hour}
+	got := r.FormatAge()
+	if got == (7 * 24 * time.Hour).String() {
+		t.Errorf("FormatAge fell through to time.Duration.String(): %q", got)
+	}
+}
+
+func TestFormatCost(t *testing.T) {
+	cases := []struct {
+		name string
+		cost float64
+		want string
+	}{
+		{"3.6 gets two decimals", 3.6, "$3.60"},
+		{"zero", 0, "$0.00"},
+		{"integer", 10, "$10.00"},
+		{"rounds to two decimals", 1.239, "$1.24"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := DeadResource{MonthlyCost: c.cost}
+			got := r.FormatCost()
+			if got != c.want {
+				t.Errorf("FormatCost(%v) = %q, want %q", c.cost, got, c.want)
+			}
+		})
+	}
+}
+
+// A nil Tags map must survive normal read access. Go's spec guarantees this,
+// but scanners construct DeadResource in several places and it's worth
+// pinning the invariant so a careless refactor can't regress it.
+func TestDeadResource_NilTagsDoesNotPanic(t *testing.T) {
+	r := DeadResource{}
+	defer func() {
+		if p := recover(); p != nil {
+			t.Fatalf("reading nil Tags panicked: %v", p)
+		}
+	}()
+	_ = r.Tags["anything"]
+	if _, ok := r.Tags["Name"]; ok {
+		t.Errorf("nil map unexpectedly reported key present")
+	}
+	if n := len(r.Tags); n != 0 {
+		t.Errorf("len(nil tags) = %d, want 0", n)
+	}
+}
+
+func TestDeadResource_EmptyFieldsFormatWithoutPanic(t *testing.T) {
+	r := DeadResource{}
+	defer func() {
+		if p := recover(); p != nil {
+			t.Fatalf("formatting empty DeadResource panicked: %v", p)
+		}
+	}()
+	if got := r.FormatAge(); got != "-" {
+		t.Errorf("empty FormatAge = %q, want %q", got, "-")
+	}
+	if got := r.FormatCost(); got != "$0.00" {
+		t.Errorf("empty FormatCost = %q, want %q", got, "$0.00")
+	}
+}

--- a/pkg/estimator/estimator.go
+++ b/pkg/estimator/estimator.go
@@ -1,0 +1,43 @@
+// Package estimator returns rough monthly USD cost estimates for AWS
+// resources flagged by the rey scanners. Prices are intentionally
+// conservative us-east-1 list prices — callers that need region-aware or
+// savings-plan pricing should layer on top of this baseline.
+package estimator
+
+// Resource type identifiers accepted by Estimate. Keep these stable — they
+// are compared as strings from scanner code.
+const (
+	TypeEIP         = "eip"
+	TypeEBS         = "ebs"
+	TypeSnapshot    = "snapshot"
+	TypeRDS         = "rds"
+	TypeS3Multipart = "s3-multipart"
+	TypeNAT         = "nat"
+	TypeVPCEndpoint = "vpc-endpoint"
+)
+
+// Estimate returns the monthly USD cost for a resource of the given type.
+// For per-GB resources (ebs, snapshot, rds, s3-multipart) sizeGB scales the
+// result; flat-priced resources (eip, nat, vpc-endpoint) ignore sizeGB.
+// Unknown resource types return 0 rather than an error: scanners should
+// surface the resource even when we can't price it.
+func Estimate(resourceType string, sizeGB float64) float64 {
+	switch resourceType {
+	case TypeEIP:
+		return 3.60
+	case TypeEBS:
+		return sizeGB * 0.10
+	case TypeSnapshot:
+		return sizeGB * 0.095
+	case TypeRDS:
+		return sizeGB * 0.115
+	case TypeS3Multipart:
+		return sizeGB * 0.023
+	case TypeNAT:
+		return 32.40
+	case TypeVPCEndpoint:
+		return 7.20
+	default:
+		return 0
+	}
+}

--- a/pkg/estimator/estimator_test.go
+++ b/pkg/estimator/estimator_test.go
@@ -1,0 +1,43 @@
+package estimator
+
+import "testing"
+
+func TestEstimate(t *testing.T) {
+	cases := []struct {
+		name         string
+		resourceType string
+		sizeGB       float64
+		want         float64
+	}{
+		{"EIP flat price", TypeEIP, 0, 3.60},
+		{"EIP ignores size", TypeEIP, 1000, 3.60},
+		{"EBS 100GB", TypeEBS, 100, 10.00},
+		{"EBS 1GB", TypeEBS, 1, 0.10},
+		{"Snapshot 100GB", TypeSnapshot, 100, 9.50},
+		{"RDS 100GB", TypeRDS, 100, 11.50},
+		{"S3 multipart 10GB", TypeS3Multipart, 10, 0.23},
+		{"NAT gateway", TypeNAT, 0, 32.40},
+		{"VPC endpoint", TypeVPCEndpoint, 0, 7.20},
+		{"Unknown type", "not-a-real-type", 100, 0},
+		{"Empty type", "", 100, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Estimate(c.resourceType, c.sizeGB)
+			if !almostEqual(got, c.want) {
+				t.Errorf("Estimate(%q, %v) = %v, want %v", c.resourceType, c.sizeGB, got, c.want)
+			}
+		})
+	}
+}
+
+// almostEqual tolerates the tiny float drift produced by multiplying
+// non-terminating binary fractions like 0.023 * 10 = 0.22999999999999998.
+func almostEqual(a, b float64) bool {
+	const epsilon = 1e-9
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	return d < epsilon
+}


### PR DESCRIPTION
This pull request refactors the threshold resolution logic, improves test coverage, and extracts pure decision helpers for EC2 and EBS scanning. The main focus is on making threshold layering more explicit and testable, and on making the resource-flagging logic independently testable and less error-prone.

**Threshold resolution improvements:**

* Introduced a new `ResolveThresholds` function in `internal/config/thresholds.go` to layer CLI flag values over config defaults, with clear semantics for unset (`-1`) and explicit zero values. The CLI flag handling in `cmd/dig.go` now builds a map of flag values and delegates merging to this function. [[1]](diffhunk://#diff-90edb7d4526b32ded539235a8468013b7efd27b8cde60b95c21888cf787082b5R35-R60) [[2]](diffhunk://#diff-085400d9eb8ef4bb7a942806a13ae6c1c8f6242c45d632d03cfbbb2a9977424cL64-R82)
* Added comprehensive unit tests for `DefaultThresholds` and `ResolveThresholds` in `internal/config/thresholds_test.go`, ensuring correct layering and field mapping.

**Scanner logic refactoring and testability:**

* Extracted pure helper functions `considerEBSVolume` and `considerEC2Instance` from the EBS and EC2 scanners, respectively. These helpers encapsulate the decision logic for flagging resources, making them independently testable and improving code clarity. [[1]](diffhunk://#diff-46f8cd4cd117cf137843db0591dc1bf0c03524ace3643f60b7aeac5af3aba45fL36-R70) [[2]](diffhunk://#diff-46f8cd4cd117cf137843db0591dc1bf0c03524ace3643f60b7aeac5af3aba45fL72-R99) [[3]](diffhunk://#diff-1056de04f7a65e65c42e8f5000f442802b9f16bbcb02b0e80f1cd130e649b4e2L23) [[4]](diffhunk://#diff-1056de04f7a65e65c42e8f5000f442802b9f16bbcb02b0e80f1cd130e649b4e2L38-R72) [[5]](diffhunk://#diff-1056de04f7a65e65c42e8f5000f442802b9f16bbcb02b0e80f1cd130e649b4e2L67-R93)
* Added thorough unit tests for the new helpers in `internal/scanner/ebs_test.go` and `internal/scanner/ec2_test.go`, covering threshold edge cases, cost calculations, and handling of malformed or missing data. [[1]](diffhunk://#diff-24da7ed586c43e2a99da109a3dc2032f9af2a278ff017f117393ee9b232a9d3aR1-R89) [[2]](diffhunk://#diff-23ef91bce0962c549d5078b4ee01d7d7bafef1b02f6ce28e7b15d4c8519ac664R1-R87)

**Output and style testing:**

* Added tests for the `RenderGraveyard` output and cost styling logic in `internal/output/table_test.go`, verifying correct rendering and color assignment based on cost.

**Minor codebase improvements:**

* Fixed a missing import alias for `ec2types` in `internal/scanner/security_group.go`.